### PR TITLE
Disable Renovate updates for vendir

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,5 +2,6 @@
   "extends": [
     // Base config - https://github.com/giantswarm/renovate-presets/blob/main/default.json5
     "github>giantswarm/renovate-presets:default.json5",
+    "github>giantswarm/renovate-presets:disable-vendir.json5",
   ],
 }


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>


This PR:
-  Disable renovate for vendir, as we need self-hosted runners to run `sync.sh`.
