### PR TITLE
chore(deps): update envoy gateway to v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update Envoy Gateway to [v1.8.1](https://gateway.envoyproxy.io/news/releases/notes/v1.8.1) (data plane Envoy bumped to v1.38.1).
+
 ## [1.7.1] - 2026-05-28
 
 ### Changed

--- a/crds/gateway.envoyproxy.io_backends.yaml
+++ b/crds/gateway.envoyproxy.io_backends.yaml
@@ -241,8 +241,39 @@ spec:
                     description: |-
                       Ciphers specifies the set of cipher suites supported when
                       negotiating TLS 1.0 - 1.2. This setting has no effect for TLS 1.3.
-                      For the list of supported ciphers, please refer to the Envoy documentation:
+                      For Envoy TLS cipher suite configuration semantics and default cipher
+                      lists, see the Envoy documentation:
                       https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#extensions-transport-sockets-tls-v3-tlsparameters
+                      Supported cipher suite names:
+                      - ECDHE-ECDSA-AES128-GCM-SHA256
+                      - ECDHE-RSA-AES128-GCM-SHA256
+                      - ECDHE-ECDSA-AES256-GCM-SHA384
+                      - ECDHE-RSA-AES256-GCM-SHA384
+                      - ECDHE-ECDSA-CHACHA20-POLY1305
+                      - ECDHE-RSA-CHACHA20-POLY1305
+                      - ECDHE-ECDSA-AES128-SHA
+                      - ECDHE-RSA-AES128-SHA
+                      - AES128-GCM-SHA256
+                      - AES128-SHA
+                      - ECDHE-ECDSA-AES256-SHA
+                      - ECDHE-RSA-AES256-SHA
+                      - AES256-GCM-SHA384
+                      - AES256-SHA
+                      Supported IANA/RFC aliases:
+                      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+                      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+                      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+                      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+                      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+                      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+                      - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+                      - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+                      - TLS_RSA_WITH_AES_128_GCM_SHA256
+                      - TLS_RSA_WITH_AES_128_CBC_SHA
+                      - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+                      - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+                      - TLS_RSA_WITH_AES_256_GCM_SHA384
+                      - TLS_RSA_WITH_AES_256_CBC_SHA
                       In non-FIPS Envoy Proxy builds the default cipher list is:
                       - [ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]
                       - [ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]

--- a/crds/gateway.envoyproxy.io_clienttrafficpolicies.yaml
+++ b/crds/gateway.envoyproxy.io_clienttrafficpolicies.yaml
@@ -1352,8 +1352,39 @@ spec:
                     description: |-
                       Ciphers specifies the set of cipher suites supported when
                       negotiating TLS 1.0 - 1.2. This setting has no effect for TLS 1.3.
-                      For the list of supported ciphers, please refer to the Envoy documentation:
+                      For Envoy TLS cipher suite configuration semantics and default cipher
+                      lists, see the Envoy documentation:
                       https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#extensions-transport-sockets-tls-v3-tlsparameters
+                      Supported cipher suite names:
+                      - ECDHE-ECDSA-AES128-GCM-SHA256
+                      - ECDHE-RSA-AES128-GCM-SHA256
+                      - ECDHE-ECDSA-AES256-GCM-SHA384
+                      - ECDHE-RSA-AES256-GCM-SHA384
+                      - ECDHE-ECDSA-CHACHA20-POLY1305
+                      - ECDHE-RSA-CHACHA20-POLY1305
+                      - ECDHE-ECDSA-AES128-SHA
+                      - ECDHE-RSA-AES128-SHA
+                      - AES128-GCM-SHA256
+                      - AES128-SHA
+                      - ECDHE-ECDSA-AES256-SHA
+                      - ECDHE-RSA-AES256-SHA
+                      - AES256-GCM-SHA384
+                      - AES256-SHA
+                      Supported IANA/RFC aliases:
+                      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+                      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+                      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+                      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+                      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+                      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+                      - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+                      - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+                      - TLS_RSA_WITH_AES_128_GCM_SHA256
+                      - TLS_RSA_WITH_AES_128_CBC_SHA
+                      - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+                      - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+                      - TLS_RSA_WITH_AES_256_GCM_SHA384
+                      - TLS_RSA_WITH_AES_256_CBC_SHA
                       In non-FIPS Envoy Proxy builds the default cipher list is:
                       - [ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]
                       - [ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]

--- a/crds/gateway.envoyproxy.io_envoyproxies.yaml
+++ b/crds/gateway.envoyproxy.io_envoyproxies.yaml
@@ -73,8 +73,39 @@ spec:
                     description: |-
                       Ciphers specifies the set of cipher suites supported when
                       negotiating TLS 1.0 - 1.2. This setting has no effect for TLS 1.3.
-                      For the list of supported ciphers, please refer to the Envoy documentation:
+                      For Envoy TLS cipher suite configuration semantics and default cipher
+                      lists, see the Envoy documentation:
                       https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#extensions-transport-sockets-tls-v3-tlsparameters
+                      Supported cipher suite names:
+                      - ECDHE-ECDSA-AES128-GCM-SHA256
+                      - ECDHE-RSA-AES128-GCM-SHA256
+                      - ECDHE-ECDSA-AES256-GCM-SHA384
+                      - ECDHE-RSA-AES256-GCM-SHA384
+                      - ECDHE-ECDSA-CHACHA20-POLY1305
+                      - ECDHE-RSA-CHACHA20-POLY1305
+                      - ECDHE-ECDSA-AES128-SHA
+                      - ECDHE-RSA-AES128-SHA
+                      - AES128-GCM-SHA256
+                      - AES128-SHA
+                      - ECDHE-ECDSA-AES256-SHA
+                      - ECDHE-RSA-AES256-SHA
+                      - AES256-GCM-SHA384
+                      - AES256-SHA
+                      Supported IANA/RFC aliases:
+                      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+                      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+                      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+                      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+                      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+                      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+                      - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+                      - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+                      - TLS_RSA_WITH_AES_128_GCM_SHA256
+                      - TLS_RSA_WITH_AES_128_CBC_SHA
+                      - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+                      - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+                      - TLS_RSA_WITH_AES_256_GCM_SHA384
+                      - TLS_RSA_WITH_AES_256_CBC_SHA
                       In non-FIPS Envoy Proxy builds the default cipher list is:
                       - [ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]
                       - [ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]

--- a/diffs/helm__envoy-gateway__templates___helpers.tpl.patch
+++ b/diffs/helm__envoy-gateway__templates___helpers.tpl.patch
@@ -1,5 +1,5 @@
 diff --git a/vendor/gateway-helm/templates/_helpers.tpl b/helm/envoy-gateway/templates/_helpers.tpl
-index db56f73..be25684 100644
+index 3f10daa..ccbebd6 100644
 --- a/vendor/gateway-helm/templates/_helpers.tpl
 +++ b/helm/envoy-gateway/templates/_helpers.tpl
 @@ -47,6 +47,7 @@ helm.sh/chart: {{ include "eg.chart" . }}

--- a/diffs/helm__envoy-gateway__values.yaml.patch
+++ b/diffs/helm__envoy-gateway__values.yaml.patch
@@ -1,5 +1,5 @@
 diff --git a/vendor/gateway-helm/values.yaml b/helm/envoy-gateway/values.yaml
-index 0338c74..4b09ccd 100644
+index af43749..f4b691d 100644
 --- a/vendor/gateway-helm/values.yaml
 +++ b/helm/envoy-gateway/values.yaml
 @@ -2,7 +2,8 @@
@@ -16,8 +16,8 @@ index 0338c74..4b09ccd 100644
    images:
      envoyGateway:
        # This is the full image name including the hub, repo, and tag.
--      image: docker.io/envoyproxy/gateway:v1.8.0
-+      image: gsoci.azurecr.io/giantswarm/envoyproxy-gateway:v1.8.0
+-      image: docker.io/envoyproxy/gateway:v1.8.1
++      image: gsoci.azurecr.io/giantswarm/envoyproxy-gateway:v1.8.1
        # Specify image pull policy if default behavior isn't desired.
        # Default behavior: latest images will be Always else IfNotPresent.
        pullPolicy: IfNotPresent
@@ -35,7 +35,7 @@ index 0338c74..4b09ccd 100644
        # This is the full image name including the hub, repo, and tag for the Envoy Proxy data plane.
        # If not specified, uses the default image built into envoy-gateway.
 -      image: ""
-+      image: "gsoci.azurecr.io/giantswarm/envoy:distroless-v1.38.0"
++      image: "gsoci.azurecr.io/giantswarm/envoy:distroless-v1.38.1"
        # Specify image pull policy if default behavior isn't desired.
        # Default behavior: IfNotPresent.
 -      pullPolicy: ""

--- a/helm/envoy-gateway/Chart.yaml
+++ b/helm/envoy-gateway/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "1.8.0"
+appVersion: "1.8.1"
 description: The Helm chart for Envoy Gateway
 home: https://github.com/giantswarm/envoy-gateway-app
 icon: https://s.giantswarm.io/app-icons/giantswarm/1/light.svg

--- a/helm/envoy-gateway/README.md
+++ b/helm/envoy-gateway/README.md
@@ -100,10 +100,10 @@ To uninstall the chart:
 | deployment.replicas | int | `1` |  |
 | global.image | object | `{"registry":"gsoci.azurecr.io"}` | Global override for image registry |
 | global.imagePullSecrets | list | `[]` | Global override for image pull secrets |
-| global.images.envoyGateway.image | string | `"gsoci.azurecr.io/giantswarm/envoyproxy-gateway:v1.8.0"` |  |
+| global.images.envoyGateway.image | string | `"gsoci.azurecr.io/giantswarm/envoyproxy-gateway:v1.8.1"` |  |
 | global.images.envoyGateway.pullPolicy | string | `"IfNotPresent"` |  |
 | global.images.envoyGateway.pullSecrets | list | `[]` |  |
-| global.images.envoyProxy.image | string | `"gsoci.azurecr.io/giantswarm/envoy:distroless-v1.38.0"` |  |
+| global.images.envoyProxy.image | string | `"gsoci.azurecr.io/giantswarm/envoy:distroless-v1.38.1"` |  |
 | global.images.envoyProxy.pullPolicy | string | `"IfNotPresent"` |  |
 | global.images.envoyProxy.pullSecrets | list | `[]` |  |
 | global.images.ratelimit.image | string | `"gsoci.azurecr.io/giantswarm/envoyproxy-ratelimit:ff287602"` |  |

--- a/helm/envoy-gateway/templates/_helpers.tpl
+++ b/helm/envoy-gateway/templates/_helpers.tpl
@@ -169,7 +169,7 @@ Resolve the Envoy Proxy image.
 {{-   $repositoryTag := $imageParts._1 -}}
 {{-   $repositoryParts := splitn ":" 2 $repositoryTag -}}
 {{-   $repositoryName := $repositoryParts._0 -}}
-{{-   $imageTag := default "distroless-v1.38.0" $repositoryParts._1 -}}
+{{-   $imageTag := default "distroless-v1.38.1" $repositoryParts._1 -}}
 {{-   printf "%s/%s:%s" $registryName $repositoryName $imageTag -}}
 {{- end -}}
 

--- a/helm/envoy-gateway/templates/envoy-gateway-hpa.yaml
+++ b/helm/envoy-gateway/templates/envoy-gateway-hpa.yaml
@@ -12,7 +12,7 @@ spec:
   {{- if .Values.hpa.minReplicas }}
   minReplicas: {{ .Values.hpa.minReplicas }}
   {{- end }}
-  maxReplicas: {{ required ".Values.hps.maxReplicas is required when hpa is enabled" .Values.hpa.maxReplicas }}
+  maxReplicas: {{ required ".Values.hpa.maxReplicas is required when hpa is enabled" .Values.hpa.maxReplicas }}
   {{- if .Values.hpa.behavior }}
   behavior:
 {{ toYaml .Values.hpa.behavior | indent 4 }}

--- a/helm/envoy-gateway/values.yaml
+++ b/helm/envoy-gateway/values.yaml
@@ -12,7 +12,7 @@ global:
   images:
     envoyGateway:
       # This is the full image name including the hub, repo, and tag.
-      image: gsoci.azurecr.io/giantswarm/envoyproxy-gateway:v1.8.0
+      image: gsoci.azurecr.io/giantswarm/envoyproxy-gateway:v1.8.1
       # Specify image pull policy if default behavior isn't desired.
       # Default behavior: latest images will be Always else IfNotPresent.
       pullPolicy: IfNotPresent
@@ -29,7 +29,7 @@ global:
     envoyProxy:
       # This is the full image name including the hub, repo, and tag for the Envoy Proxy data plane.
       # If not specified, uses the default image built into envoy-gateway.
-      image: "gsoci.azurecr.io/giantswarm/envoy:distroless-v1.38.0"
+      image: "gsoci.azurecr.io/giantswarm/envoy:distroless-v1.38.1"
       # Specify image pull policy if default behavior isn't desired.
       # Default behavior: IfNotPresent.
       pullPolicy: IfNotPresent

--- a/sync/patches/values/values.yaml
+++ b/sync/patches/values/values.yaml
@@ -12,7 +12,7 @@ global:
   images:
     envoyGateway:
       # This is the full image name including the hub, repo, and tag.
-      image: gsoci.azurecr.io/giantswarm/envoyproxy-gateway:v1.8.0
+      image: gsoci.azurecr.io/giantswarm/envoyproxy-gateway:v1.8.1
       # Specify image pull policy if default behavior isn't desired.
       # Default behavior: latest images will be Always else IfNotPresent.
       pullPolicy: IfNotPresent
@@ -29,7 +29,7 @@ global:
     envoyProxy:
       # This is the full image name including the hub, repo, and tag for the Envoy Proxy data plane.
       # If not specified, uses the default image built into envoy-gateway.
-      image: "gsoci.azurecr.io/giantswarm/envoy:distroless-v1.38.0"
+      image: "gsoci.azurecr.io/giantswarm/envoy:distroless-v1.38.1"
       # Specify image pull policy if default behavior isn't desired.
       # Default behavior: IfNotPresent.
       pullPolicy: IfNotPresent

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -2,8 +2,8 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - helmChart:
-      appVersion: v1.8.0
-      version: v1.8.0
+      appVersion: v1.8.1
+      version: v1.8.1
     path: gateway-helm
   path: vendor
 - contents:

--- a/vendir.yml
+++ b/vendir.yml
@@ -6,7 +6,7 @@ directories:
   - path: gateway-helm
     helmChart:
       name: gateway-helm
-      version: v1.8.0
+      version: v1.8.1
       repository:
         url: oci://docker.io/envoyproxy
 - path: helm/envoy-gateway


### PR DESCRIPTION
## What

Upgrades the upstream Envoy Gateway chart from **v1.8.0 → v1.8.1**.

## Changes

- `vendir.yml` / `vendir.lock.yml` — chart version bumped to `v1.8.1`
- `sync/patches/values/values.yaml` — updated mirrored image tags:
  - `envoyproxy-gateway`: `v1.8.0` → `v1.8.1`
  - `envoy` (data plane): `distroless-v1.38.0` → `distroless-v1.38.1` (upstream bumped Envoy to 1.38.1)
  - Verified both tags exist in the `gsoci.azurecr.io` mirror
- `helm/envoy-gateway/` — regenerated via `./sync/sync.sh` (no patch conflicts): `Chart.yaml` appVersion → `1.8.1`, `_helpers.tpl` default proxy tag → `distroless-v1.38.1`, an upstream HPA typo fix (`hps`→`hpa`), additive CRD schema updates, README
- `CHANGELOG.md` — entry added under `## [Unreleased]`

## Verification

- `./sync/sync.sh` ran clean
- `helm template` and `helm lint` pass

Upstream release notes: https://gateway.envoyproxy.io/news/releases/notes/v1.8.1