### PR TITLE
fix(cnp): correct ingress ports path and format string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Import load testing framework from microservices-demo app.
 
+### Fixed
+
+- Correct the ports path and format in the Envoy Gateway ingress `CiliumNetworkPolicy`. The previous empty `toPorts` entry put the endpoint into default-deny mode, silently dropping all xDS connections from new proxy pods.
+
 ## [1.7.2] - 2026-06-08
 
 ### Changed

--- a/diffs/helm__envoy-gateway__templates__envoy-gateway-cnp.yaml.patch
+++ b/diffs/helm__envoy-gateway__templates__envoy-gateway-cnp.yaml.patch
@@ -1,6 +1,6 @@
 diff --git a/helm/envoy-gateway/templates/envoy-gateway-cnp.yaml b/helm/envoy-gateway/templates/envoy-gateway-cnp.yaml
 new file mode 100644
-index 0000000..16081e3
+index 0000000..9438290
 --- /dev/null
 +++ b/helm/envoy-gateway/templates/envoy-gateway-cnp.yaml
 @@ -0,0 +1,44 @@
@@ -44,7 +44,7 @@ index 0000000..16081e3
 +        - cluster
 +      toPorts:
 +        - ports:
-+            {{- range .Values.deployment.envoyGateway.ports }}
-+            - port: {{ printf "\"%d\"" .port }}
++            {{- range .Values.deployment.ports }}
++            - port: {{ .port | int | toString | quote }}
 +              protocol: TCP
 +            {{- end }}

--- a/diffs/helm__envoy-gateway__templates__envoy-gateway-netpol.yaml.patch
+++ b/diffs/helm__envoy-gateway__templates__envoy-gateway-netpol.yaml.patch
@@ -1,6 +1,6 @@
 diff --git a/helm/envoy-gateway/templates/envoy-gateway-netpol.yaml b/helm/envoy-gateway/templates/envoy-gateway-netpol.yaml
 new file mode 100644
-index 0000000..9d9049d
+index 0000000..c3d2d58
 --- /dev/null
 +++ b/helm/envoy-gateway/templates/envoy-gateway-netpol.yaml
 @@ -0,0 +1,45 @@
@@ -43,7 +43,7 @@ index 0000000..9d9049d
 +          protocol: TCP
 +  ingress:
 +    - ports:
-+        {{- range .Values.deployment.envoyGateway.ports }}
++        {{- range .Values.deployment.ports }}
 +        - port: {{ .port }}
 +          protocol: TCP
 +        {{- end }}

--- a/helm/envoy-gateway/templates/envoy-gateway-cnp.yaml
+++ b/helm/envoy-gateway/templates/envoy-gateway-cnp.yaml
@@ -38,7 +38,7 @@ spec:
         - cluster
       toPorts:
         - ports:
-            {{- range .Values.deployment.envoyGateway.ports }}
-            - port: {{ printf "\"%d\"" .port }}
+            {{- range .Values.deployment.ports }}
+            - port: {{ .port | int | toString | quote }}
               protocol: TCP
             {{- end }}

--- a/helm/envoy-gateway/templates/envoy-gateway-netpol.yaml
+++ b/helm/envoy-gateway/templates/envoy-gateway-netpol.yaml
@@ -37,7 +37,7 @@ spec:
           protocol: TCP
   ingress:
     - ports:
-        {{- range .Values.deployment.envoyGateway.ports }}
+        {{- range .Values.deployment.ports }}
         - port: {{ .port }}
           protocol: TCP
         {{- end }}

--- a/sync/patches/network-policies/000-network-policies.patch
+++ b/sync/patches/network-policies/000-network-policies.patch
@@ -143,8 +143,8 @@ index 0000000..a44b6ee
 +        - cluster
 +      toPorts:
 +        - ports:
-+            {{- range .Values.deployment.envoyGateway.ports }}
-+            - port: {{ printf "\"%d\"" .port }}
++            {{- range .Values.deployment.ports }}
++            - port: {{ .port | int | toString | quote }}
 +              protocol: TCP
 +            {{- end }}
 diff --git a/helm/envoy-gateway/templates/envoy-gateway-netpol.yaml b/helm/envoy-gateway/templates/envoy-gateway-netpol.yaml
@@ -192,7 +192,7 @@ index 0000000..9d9049d
 +          protocol: TCP
 +  ingress:
 +    - ports:
-+        {{- range .Values.deployment.envoyGateway.ports }}
++        {{- range .Values.deployment.ports }}
 +        - port: {{ .port }}
 +          protocol: TCP
 +        {{- end }}


### PR DESCRIPTION
## Problem

The CiliumNetworkPolicy for the envoy-gateway control plane pod rendered a broken ingress rule on every install/upgrade:

```yaml
ingress:
  - fromEntities:
      - cluster
    toPorts:
      - {}   # should be a list of ports
```

This causes Cilium to select the endpoint into default-deny mode (policy enforcement enabled) with an empty allow-list, dropping all ingress TCP connections — including xDS connections from envoy proxy pods.

## Root cause

Two bugs in `templates/envoy-gateway-cnp.yaml`:

1. **Wrong values path**: template iterated `.Values.deployment.envoyGateway.ports` which does not exist; the ports live at `.Values.deployment.ports`. Empty range → empty `ports:` list → PortRule collapses to `{}`.

2. **Bad format string**: `printf "\"%d\"" .port` fails on `float64` values (Helm parses YAML integers as float64), producing `%!d(float64=18000)`. Fixed with `int | toString | quote`.

## Why it wasn't obvious

The bug exists since the chart was written but only manifests for *new* TCP connections. Pods that established their xDS gRPC stream before the CNP was applied (during `pre-install` hook creation) have existing entries in Cilium's conntrack table and are not affected. Only pods starting after the CNP is in place — including every pod created during a node rolling upgrade — hit the deny.

## Fix

```diff
-{{- range .Values.deployment.envoyGateway.ports }}
-  - port: {{ printf "\"%d\"" .port }}
+{{- range .Values.deployment.ports }}
+  - port: {{ .port | int | toString | quote }}
```