### PR TITLE
chore(tests): Add circuitbreaker bundlevalues performance test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `basicauth` performance test suite.
 
+### Changed
+
+- Add `circuitBreaker` config field in bundle values for envoy performance test suites to better sustain high request load.
+
 ## [1.7.3] - 2026-06-09
 
 ### Added

--- a/tests/performance/suites/basic/bundle_values.yaml
+++ b/tests/performance/suites/basic/bundle_values.yaml
@@ -6,6 +6,12 @@ apps:
         values: |
           gateways:
             default:
+              backendTrafficPolicy:
+                circuitBreaker:
+                  maxConnections: 8192
+                  maxPendingRequests: 8192
+                  maxParallelRequests: 8192
+                  maxParallelRetries: 1024
               envoyProxy:
                 enabled: true
               allowedListeners:

--- a/tests/performance/suites/basicauth/bundle_values.yaml
+++ b/tests/performance/suites/basicauth/bundle_values.yaml
@@ -6,6 +6,12 @@ apps:
         values: |
           gateways:
             default:
+              backendTrafficPolicy:
+                circuitBreaker:
+                  maxConnections: 8192
+                  maxPendingRequests: 8192
+                  maxParallelRequests: 8192
+                  maxParallelRetries: 1024
               envoyProxy:
                 enabled: true
               allowedListeners:


### PR DESCRIPTION
This PR adds a circuitBreaker field in the gateway-api-bundle config in envoy performance test suites to allow for a better reliability of the default Envoy Gateway under high request load in such environments.

### Checklist

- [x] Update changelog in CHANGELOG.md.
