### PR TITLE
chore(tests): add key auth performance test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `basicauth` performance test suite.
+- Add `keyauth` performance test suite.
 
 ### Changed
 

--- a/tests/performance/suites/keyauth/auth_test.go
+++ b/tests/performance/suites/keyauth/auth_test.go
@@ -1,0 +1,301 @@
+package keyauth
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/giantswarm/apptest-framework/v5/pkg/state"
+	"github.com/giantswarm/clustertest/v5/pkg/logger"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	cr "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// The microservices-demo-app chart creates one HTTPRoute per endpoint
+	// namespace: frontend-{i} in loadtesting-{i} for i in [0, PUBLIC_ENDPOINTS).
+	// Envoy Gateway requires a SecurityPolicy to live in the same namespace as
+	// the HTTPRoute it targets, so enforceEnvoyKeyAuth provisions one policy +
+	// API key Secret per namespace, looping over publicEndpoints().
+	envoyRouteNamespacePrefix = "loadtesting-"
+	envoyRouteNamePrefix      = "frontend-"
+
+	// envoyAPIKeySecret holds the API keys consumed by the Envoy SecurityPolicy
+	// apiKeyAuth: each Secret data entry maps a client id -> API key value.
+	envoyAPIKeySecret = "boutique-key-auth-keys"
+
+	// apiKeyHeader is the header the gateways extract the API key from. Matches
+	// the upstream key-auth use case.
+	apiKeyHeader = "x-api-key"
+
+	// apiKeyClientID is the (arbitrary) client identifier the API key is filed
+	// under in the Envoy apiKeyAuth Secret.
+	apiKeyClientID = "boutique-client"
+
+	// Kong runs as a Gateway API implementation (its own GatewayClass), exactly
+	// like Envoy — not via Ingress. The chart's kong path is a single HTTPRoute
+	// "kong-{frontend.name}" in the loadtesting namespace serving the single
+	// host kong-onlineboutique.loadtesting.<base>. (The chart also renders
+	// frontend-kong-{i} Ingresses, but kong-app runs Gateway-API-only with
+	// ingressClass: none and the kong DNSEndpoint only publishes the single
+	// HTTPRoute host, so those Ingresses are neither routable nor reconciled.)
+	kongRouteNamespace = "loadtesting"
+	kongRouteName      = "kong-frontend"
+
+	// Kong key-auth wiring: a key-auth KongPlugin is attached to the boutique
+	// kong HTTPRoute via the konghq.com/plugins annotation, and a consumer +
+	// credential secret holds the single valid API key.
+	kongNamespace      = "kong"
+	kongCredentialName = "boutique-key-auth-cred"
+	kongConsumerName   = "boutique-consumer"
+	kongPluginName     = "boutique-key-auth"
+)
+
+// httpRouteGVK is the Gateway API HTTPRoute kind, used to fetch and annotate
+// the chart-created kong HTTPRoute.
+var httpRouteGVK = schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"}
+
+func apiKey() string { return envOrDefault("API_KEY", "k6-perf-test-api-key-9f3a2b") }
+
+// publicEndpoints is the number of boutique endpoint namespaces the chart
+// creates (httproute.namespaces.number). Must match the PUBLIC_ENDPOINTS used
+// in buildMicroservicesDemoAppValues so every frontend-{i}/loadtesting-{i} gets
+// a SecurityPolicy.
+func publicEndpoints() int {
+	n, err := strconv.Atoi(envOrDefault("PUBLIC_ENDPOINTS", "10"))
+	if err != nil || n < 1 {
+		return 10
+	}
+	return n
+}
+
+func wcClient() cr.Client {
+	wc, err := state.GetFramework().WC(state.GetCluster().Name)
+	Expect(err).NotTo(HaveOccurred())
+	return wc
+}
+
+// applySecret writes a Secret into namespace ns, replacing any stale copy from
+// a previous run.
+func applySecret(ns string, secret *corev1.Secret) {
+	wc := wcClient()
+	ctx := state.GetContext()
+	secret.Namespace = ns
+	_ = wc.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secret.Name, Namespace: ns}})
+	err := wc.Create(ctx, secret)
+	Expect(err).NotTo(HaveOccurred(), "failed to create secret %s/%s", ns, secret.Name)
+}
+
+// applyUnstructured creates obj, or updates it in place if it already exists.
+func applyUnstructured(obj *unstructured.Unstructured) {
+	wc := wcClient()
+	ctx := state.GetContext()
+
+	existing := obj.DeepCopy()
+	err := wc.Get(ctx, cr.ObjectKey{Name: obj.GetName(), Namespace: obj.GetNamespace()}, existing)
+	if errors.IsNotFound(err) {
+		err = wc.Create(ctx, obj)
+		Expect(err).NotTo(HaveOccurred(), "failed to create %s %s/%s", obj.GetKind(), obj.GetNamespace(), obj.GetName())
+		return
+	}
+	Expect(err).NotTo(HaveOccurred(), "failed to get %s %s/%s", obj.GetKind(), obj.GetNamespace(), obj.GetName())
+
+	obj.SetResourceVersion(existing.GetResourceVersion())
+	err = wc.Update(ctx, obj)
+	Expect(err).NotTo(HaveOccurred(), "failed to update %s %s/%s", obj.GetKind(), obj.GetNamespace(), obj.GetName())
+}
+
+// enforceEnvoyKeyAuth provisions, for each boutique endpoint namespace, a
+// SecurityPolicy with apiKeyAuth targeting that namespace's HTTPRoute plus the
+// API key Secret it references. The chart creates frontend-{i}/loadtesting-{i}
+// for every endpoint and the k6 scenario hits all of them, so a single policy
+// would leave the other endpoints unauthenticated.
+func enforceEnvoyKeyAuth() {
+	for i := 0; i < publicEndpoints(); i++ {
+		namespace := fmt.Sprintf("%s%d", envoyRouteNamespacePrefix, i)
+		route := fmt.Sprintf("%s%d", envoyRouteNamePrefix, i)
+
+		By(fmt.Sprintf("Creating the Envoy API key Secret in %s", namespace))
+		applySecret(namespace, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: envoyAPIKeySecret},
+			Type:       corev1.SecretTypeOpaque,
+			// data entry: client id -> API key value.
+			StringData: map[string]string{apiKeyClientID: apiKey()},
+		})
+
+		By(fmt.Sprintf("Applying the apiKeyAuth SecurityPolicy targeting %s/%s", namespace, route))
+		sp := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "gateway.envoyproxy.io/v1alpha1",
+			"kind":       "SecurityPolicy",
+			"metadata": map[string]any{
+				"name":      "boutique-key-auth",
+				"namespace": namespace,
+			},
+			"spec": map[string]any{
+				"targetRefs": []any{
+					map[string]any{
+						"group": "gateway.networking.k8s.io",
+						"kind":  "HTTPRoute",
+						"name":  route,
+					},
+				},
+				"apiKeyAuth": map[string]any{
+					"credentialRefs": []any{
+						map[string]any{"group": "", "kind": "Secret", "name": envoyAPIKeySecret},
+					},
+					"extractFrom": []any{
+						map[string]any{"headers": []any{apiKeyHeader}},
+					},
+				},
+			},
+		}}
+		sp.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.envoyproxy.io", Version: "v1alpha1", Kind: "SecurityPolicy"})
+		applyUnstructured(sp)
+	}
+}
+
+// enforceKongKeyAuth attaches a key-auth KongPlugin to the boutique kong
+// HTTPRoute (the Gateway API route the scenario hits) via the konghq.com/plugins
+// annotation, plus the consumer and credential that make exactly one API key
+// valid. Kong runs as a Gateway API implementation here, so enforcement targets
+// the HTTPRoute, mirroring how the Envoy side targets its HTTPRoutes.
+func enforceKongKeyAuth() {
+	By("Creating the Kong key-auth credential Secret")
+	applySecret(kongNamespace, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   kongCredentialName,
+			Labels: map[string]string{"konghq.com/credential": "key-auth"},
+		},
+		Type:       corev1.SecretTypeOpaque,
+		StringData: map[string]string{"key": apiKey()},
+	})
+
+	By("Creating the KongConsumer")
+	consumer := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "configuration.konghq.com/v1",
+		"kind":       "KongConsumer",
+		"metadata": map[string]any{
+			"name":      kongConsumerName,
+			"namespace": kongNamespace,
+			"annotations": map[string]any{
+				"kubernetes.io/ingress.class": "kong",
+			},
+		},
+		"username":    kongConsumerName,
+		"credentials": []any{kongCredentialName},
+	}}
+	consumer.SetGroupVersionKind(schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1", Kind: "KongConsumer"})
+	applyUnstructured(consumer)
+
+	By(fmt.Sprintf("Applying the key-auth KongPlugin in %s", kongRouteNamespace))
+	// key_names is set to the x-api-key header used by the scenario (Kong
+	// defaults to apikey). The KongPlugin must live in the same namespace as the
+	// HTTPRoute that references it via konghq.com/plugins.
+	plugin := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "configuration.konghq.com/v1",
+		"kind":       "KongPlugin",
+		"metadata": map[string]any{
+			"name":      kongPluginName,
+			"namespace": kongRouteNamespace,
+		},
+		"plugin": "key-auth",
+		"config": map[string]any{
+			"key_names":        []any{apiKeyHeader},
+			"hide_credentials": true,
+		},
+	}}
+	plugin.SetGroupVersionKind(schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1", Kind: "KongPlugin"})
+	applyUnstructured(plugin)
+
+	By(fmt.Sprintf("Annotating the kong HTTPRoute %s/%s with the key-auth plugin", kongRouteNamespace, kongRouteName))
+	annotateKongRoute()
+}
+
+// annotateKongRoute adds the konghq.com/plugins annotation to the chart-created
+// kong HTTPRoute, re-fetching on each attempt so a concurrent reconcile (KIC /
+// external-dns) can't lose the update to a resourceVersion conflict.
+func annotateKongRoute() {
+	wc := wcClient()
+	ctx := state.GetContext()
+
+	Eventually(func() error {
+		route := &unstructured.Unstructured{}
+		route.SetGroupVersionKind(httpRouteGVK)
+		if err := wc.Get(ctx, cr.ObjectKey{Name: kongRouteName, Namespace: kongRouteNamespace}, route); err != nil {
+			return err
+		}
+		annotations := route.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		annotations["konghq.com/plugins"] = kongPluginName
+		route.SetAnnotations(annotations)
+		return wc.Update(ctx, route)
+	}).
+		WithTimeout(5*time.Minute).
+		WithPolling(10*time.Second).
+		Should(Succeed(), "failed to annotate kong HTTPRoute %s/%s with the key-auth plugin", kongRouteNamespace, kongRouteName)
+
+	logger.Log("Attached key-auth KongPlugin to kong HTTPRoute %s/%s", kongRouteNamespace, kongRouteName)
+}
+
+// expectEndpointRequiresKey verifies the gateway enforces API key auth: a
+// request with no key is rejected with 401, while a request carrying the
+// provisioned x-api-key reaches the boutique frontend (200). Both checks poll
+// to absorb policy-propagation delay.
+func expectEndpointRequiresKey(endpoint string) {
+	httpClient := newHttpClientWithProxy(endpoint)
+	key := apiKey()
+
+	By(fmt.Sprintf("expecting %s to reject requests with no API key with 401", endpoint))
+	Eventually(func() (int, error) {
+		resp, err := httpClient.Get(endpoint)
+		if err != nil {
+			return 0, err
+		}
+		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		logger.Log("Keyless GET %s -> %d", endpoint, resp.StatusCode)
+		return resp.StatusCode, nil
+	}).
+		WithTimeout(10 * time.Minute).
+		WithPolling(10 * time.Second).
+		Should(Equal(http.StatusUnauthorized))
+
+	By(fmt.Sprintf("expecting %s to serve traffic with a valid API key", endpoint))
+	Eventually(func() (string, error) {
+		req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+		if err != nil {
+			return "", err
+		}
+		req.Header.Set(apiKeyHeader, key)
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			logger.Log("Authenticated GET %s -> %d (want 200)", endpoint, resp.StatusCode)
+			_, _ = io.Copy(io.Discard, resp.Body)
+			return "", nil
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return "", err
+		}
+		return string(body), nil
+	}).
+		WithTimeout(10 * time.Minute).
+		WithPolling(10 * time.Second).
+		Should(ContainSubstring("Online Boutique"))
+}

--- a/tests/performance/suites/keyauth/auth_test.go
+++ b/tests/performance/suites/keyauth/auth_test.go
@@ -59,6 +59,13 @@ const (
 	kongCredentialName = "boutique-key-auth-cred"
 	kongConsumerName   = "boutique-consumer"
 	kongPluginName     = "boutique-key-auth"
+
+	// kongIngressClass must match kong-app's ingressController.ingressClass
+	// (set to "none" in kongAppValues for Gateway-API-only operation). KIC gates
+	// standalone Kong CRDs like KongConsumer on kubernetes.io/ingress.class: a
+	// mismatch leaves the consumer "Waiting for controller", so its credential is
+	// never loaded into Kong and every key — valid or not — is rejected with 401.
+	kongIngressClass = "none"
 )
 
 // httpRouteGVK is the Gateway API HTTPRoute kind, used to fetch and annotate
@@ -188,7 +195,7 @@ func enforceKongKeyAuth() {
 			"name":      kongConsumerName,
 			"namespace": kongNamespace,
 			"annotations": map[string]any{
-				"kubernetes.io/ingress.class": "kong",
+				"kubernetes.io/ingress.class": kongIngressClass,
 			},
 		},
 		"username":    kongConsumerName,

--- a/tests/performance/suites/keyauth/bundle_values.yaml
+++ b/tests/performance/suites/keyauth/bundle_values.yaml
@@ -1,0 +1,33 @@
+apps:
+  gatewayApiConfig:
+    enabled: true
+    userConfig:
+      configMap:
+        values: |
+          gateways:
+            default:
+              backendTrafficPolicy:
+                circuitBreaker:
+                  maxConnections: 8192
+                  maxPendingRequests: 8192
+                  maxParallelRequests: 8192
+                  maxParallelRetries: 1024
+              envoyProxy:
+                enabled: true
+              allowedListeners:
+                enabled: true
+                namespaces:
+                  from: All
+              listeners:
+                http:
+                  httpsRedirectEnabled: true
+                  allowedRoutes:
+                    namespaces:
+                      from: All
+                https:
+                  subdomains:
+                    - onlineboutique
+                  certificate:
+                    issuer:
+                      kind: ClusterIssuer
+                      name: letsencrypt-giantswarm

--- a/tests/performance/suites/keyauth/config.env
+++ b/tests/performance/suites/keyauth/config.env
@@ -1,0 +1,46 @@
+# Shared infrastructure
+WC=envoyloadtesting
+MC=graveler
+BASE_DOMAIN=gaws2.gigantic.io
+AZ=eu-north-1a
+RELEASE=34.1.0
+MAX_NODES=10
+MIN_NODES=3
+INSTANCE_TYPE=m5.xlarge
+
+# API key enforced at the gateway in front of the microservices-demo (Online
+# Boutique) backend. The same key is provisioned on Envoy Gateway
+# (SecurityPolicy apiKeyAuth) and Kong (key-auth plugin + consumer), extracted
+# from the x-api-key header, so the k6 key-auth scenario can assert:
+# valid key -> 200, wrong/missing key -> 401.
+API_KEY=k6-perf-test-api-key-9f3a2b
+
+# Cluster contexts (kubectl context names)
+MC_CONTEXT=teleport.giantswarm.io-grizzly                # Management cluster — WC App CRs applied here
+K6_CONTEXT=teleport.giantswarm.io-grizzly                # k6 cluster — TestRun + scenario ConfigMap here
+
+# Microservices demo app configuration
+PUBLIC_ENDPOINTS=10
+HPA_MIN_REPLICAS=1
+HPA_MAX_REPLICAS=20
+
+# k6 load testing
+K6_NAMESPACE=gs-k6-operator
+K6_IMAGE=gsoci.azurecr.io/giantswarm/k6:1.6.0
+TEST_ID=envoy-load-testing
+ENDPOINTS=10
+SCENARIO_DURATION_SECONDS=1200
+WAIT_BETWEEN_SCENARIOS=300
+PEAK_HTTP_RPS=50
+RAMP_STEP_HTTP_RPS=10
+RAMP_STEP_DURATION_SECONDS=300
+PRE_ALLOCATED_VUS=50
+MAX_VUS=150
+GRACEFUL_STOP=30s
+PROMETHEUS_RW_URL=http://mimir-gateway.mimir.svc.cluster.local/api/v1/push
+K6_PROMETHEUS_RW_HTTP_HEADERS=X-Scope-OrgID:giantswarm # Must be set to the <key>:<value> format. Multiple headers can be separated by commas, e.g. "Header1:Value1,Header2:Value2"
+PROMETHEUS_RW_PUSH_INTERVAL=5s
+SLO_P95_LATENCY_MS=500
+SLO_P99_LATENCY_MS=1000
+SLO_ERROR_RATE=0.001
+SLO_CHECKS_RATE=0.95

--- a/tests/performance/suites/keyauth/config_env_test.go
+++ b/tests/performance/suites/keyauth/config_env_test.go
@@ -1,0 +1,79 @@
+package keyauth
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+var configEnvOnce sync.Once
+
+// infraConfigKeys are config.env entries that identify the manual
+// load-testing pipeline's specific, long-lived cluster (management cluster,
+// workload cluster name, base domain, kube contexts). The e2e suite
+// provisions its own ephemeral workload cluster and discovers these at
+// runtime, so importing them from config.env would point the suite at the
+// wrong installation — e.g. a base domain with no matching Route 53 hosted
+// zone, which leaves every Let's Encrypt certificate stuck on DNS-01.
+var infraConfigKeys = map[string]bool{
+	"WC":          true,
+	"MC":          true,
+	"BASE_DOMAIN": true,
+	"MC_CONTEXT":  true,
+	"K6_CONTEXT":  true,
+}
+
+// loadConfigEnv seeds the process environment from the suite-local
+// config.env on first call, so the e2e suite shares app-tuning defaults
+// (PUBLIC_ENDPOINTS, HPA_*, k6 knobs) with the manual load-testing
+// pipeline. Infrastructure-identity keys (see infraConfigKeys)
+// are deliberately skipped — those are specific to the manual pipeline's
+// cluster and must be discovered at runtime for the ephemeral e2e cluster.
+// Real env vars already set by the Tekton pipeline (or a local override)
+// always win — this only fills in what's missing.
+//
+// File format mirrors `set -a; source config.env; set +a`: KEY=value lines,
+// '#' line comments, and ' #' inline comments stripped from values. Quotes
+// are not interpreted (none of the keys in config.env use them).
+func loadConfigEnv() {
+	configEnvOnce.Do(func() {
+		_, thisFile, _, ok := runtime.Caller(0)
+		if !ok {
+			return
+		}
+		path := filepath.Join(filepath.Dir(thisFile), "config.env")
+		f, err := os.Open(path)
+		if err != nil {
+			return
+		}
+		defer f.Close()
+
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+			eq := strings.IndexByte(line, '=')
+			if eq <= 0 {
+				continue
+			}
+			key := strings.TrimSpace(line[:eq])
+			if infraConfigKeys[key] {
+				continue
+			}
+			value := line[eq+1:]
+			if i := strings.Index(value, " #"); i >= 0 {
+				value = value[:i]
+			}
+			value = strings.TrimSpace(value)
+			if _, set := os.LookupEnv(key); set {
+				continue
+			}
+			_ = os.Setenv(key, value)
+		}
+	})
+}

--- a/tests/performance/suites/keyauth/dependencies_test.go
+++ b/tests/performance/suites/keyauth/dependencies_test.go
@@ -1,0 +1,202 @@
+package keyauth
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	applicationv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
+	"github.com/giantswarm/apptest-framework/v5/pkg/state"
+	"github.com/giantswarm/clustertest/v5/pkg/application"
+	"github.com/giantswarm/clustertest/v5/pkg/logger"
+	"github.com/giantswarm/clustertest/v5/pkg/wait"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const awsLBControllerBundleValues = `
+managementCluster:
+  name: %s
+  namespace: org-giantswarm
+
+clusterName: %s
+clusterID: %s
+
+provider: aws
+
+global:
+  podSecurityStandards:
+    enforced: true
+
+enableServiceMutatorWebhook: false
+`
+
+const kongAppValues = `
+ingressController:
+  enabled: true
+  createIngressClass: false
+  watchNamespaces:
+    - loadtesting
+    - kong
+  rbac:
+    gatewayAPI:
+      enabled: true
+  ingressClass: none  # Prevents KIC from reconciling Ingress resources; Gateway API only
+proxy:
+  annotations:
+    giantswarm.io/external-dns: managed
+    external-dns.alpha.kubernetes.io/hostname: kong-ingress.%s
+`
+
+// kongExtraObjectsValues is applied as an extraConfig overlay AFTER kong-app is
+// deployed and its KongClusterPlugin CRD is registered. Inlining these into the
+// initial kongAppValues fails on first install because Helm renders
+// extraObjects before the chart's own CRDs are applied.
+const kongExtraObjectsValues = `
+extraObjects:
+  - apiVersion: configuration.konghq.com/v1
+    kind: KongClusterPlugin
+    metadata:
+      name: prometheus
+      annotations:
+        kubernetes.io/ingress.class: kong
+      labels:
+        global: "true"
+    plugin: prometheus
+    config:
+      status_code_metrics: true
+      latency_metrics: true
+      bandwidth_metrics: true
+      upstream_health_metrics: true
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: kong-app-kong-app-ingressclass-reader
+    rules:
+      - apiGroups: ["networking.k8s.io"]
+        resources: ["ingressclasses"]
+        verbs: ["get", "list", "watch"]
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: kong-app-kong-app-ingressclass-reader
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: kong-app-kong-app-ingressclass-reader
+    subjects:
+      - kind: ServiceAccount
+        name: kong-app-kong-app
+        namespace: kong
+`
+
+// gateway-api-bundle is installed by apptest-framework via
+// InAppBundle and not listed here. This suite compares Envoy against Kong only
+// (API key auth is not natively supported by ingress-nginx), so ingress-nginx
+// is intentionally absent.
+var dependencyVersions = map[string]string{
+	"aws-lb-controller-bundle": "5.2.0",
+	"kong-app":                 "5.2.2",
+	"microservices-demo-app":   "0.8.0",
+}
+
+func deployDependency(depName, depValues string, installNs ...string) *application.Application {
+	By(fmt.Sprintf("deploying %s", depName))
+
+	org := state.GetCluster().Organization
+
+	isBundle := strings.Contains(depName, "bundle")
+	installNamespace := org.GetNamespace()
+	if !isBundle {
+		installNamespace = "default"
+	}
+	if len(installNs) > 0 && installNs[0] != "" {
+		installNamespace = installNs[0]
+	}
+
+	version, ok := dependencyVersions[depName]
+	if !ok {
+		Fail(fmt.Sprintf("no version pin defined for dependency %q — add it to dependencyVersions", depName))
+	}
+
+	clusterName := state.GetCluster().Name
+	app := application.New(fmt.Sprintf("%s-%s", clusterName, depName), depName).
+		WithCatalog("giantswarm").
+		WithOrganization(*org).
+		WithVersion(version).
+		WithClusterName(clusterName).
+		WithInCluster(isBundle).
+		WithInstallNamespace(installNamespace).
+		MustWithValues(depValues, nil)
+
+	err := state.GetFramework().MC().DeployApp(state.GetContext(), *app)
+	Expect(err).NotTo(HaveOccurred())
+
+	return app
+}
+
+func waitForDependency(app *application.Application) {
+	By(fmt.Sprintf("waiting for %s to be deployed", app.InstallName))
+
+	org := state.GetCluster().Organization
+	Eventually(wait.IsAppDeployed(state.GetContext(), state.GetFramework().MC(), app.InstallName, org.GetNamespace())).
+		WithTimeout(10 * time.Minute).
+		WithPolling(5 * time.Second).
+		Should(BeTrue())
+}
+
+// addExtraConfigToApp creates a ConfigMap with the given values and adds it
+// to the App CR's spec.extraConfigs list. Idempotent — safe to call on retry.
+func addExtraConfigToApp(appName, configMapName, values string) {
+	ctx := state.GetContext()
+	mc := state.GetFramework().MC()
+	org := state.GetCluster().Organization
+	namespace := org.GetNamespace()
+
+	logger.Log("Ensuring extra config ConfigMap %s/%s for App %s", namespace, configMapName, appName)
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			"values": values,
+		},
+	}
+	err := mc.Create(ctx, cm)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		Expect(err).NotTo(HaveOccurred(), "failed to create extra config ConfigMap %s/%s", namespace, configMapName)
+	}
+
+	// Read the current App CR to preserve existing extraConfigs
+	appCR := &applicationv1alpha1.App{}
+	err = mc.Get(ctx, types.NamespacedName{Name: appName, Namespace: namespace}, appCR)
+	Expect(err).NotTo(HaveOccurred(), "failed to get App CR %s/%s", namespace, appName)
+
+	// Check if the extra config is already present
+	for _, ec := range appCR.Spec.ExtraConfigs {
+		if ec.Name == configMapName && ec.Namespace == namespace {
+			logger.Log("Extra config %s already present on App %s/%s", configMapName, namespace, appName)
+			return
+		}
+	}
+
+	appCR.Spec.ExtraConfigs = append(appCR.Spec.ExtraConfigs, applicationv1alpha1.AppExtraConfig{
+		Kind:      "configMap",
+		Name:      configMapName,
+		Namespace: namespace,
+		Priority:  25,
+	})
+
+	err = mc.Update(ctx, appCR)
+	Expect(err).NotTo(HaveOccurred(), "failed to update App CR %s/%s with extraConfigs", namespace, appName)
+
+	logger.Log("Added extra config %s to App %s/%s", configMapName, namespace, appName)
+}

--- a/tests/performance/suites/keyauth/dependencies_test.go
+++ b/tests/performance/suites/keyauth/dependencies_test.go
@@ -103,7 +103,7 @@ extraObjects:
 var dependencyVersions = map[string]string{
 	"aws-lb-controller-bundle": "5.2.0",
 	"kong-app":                 "5.2.2",
-	"microservices-demo-app":   "0.8.0",
+	"microservices-demo-app":   "0.8.1",
 }
 
 func deployDependency(depName, depValues string, installNs ...string) *application.Application {

--- a/tests/performance/suites/keyauth/dependencies_test.go
+++ b/tests/performance/suites/keyauth/dependencies_test.go
@@ -65,7 +65,7 @@ extraObjects:
     metadata:
       name: prometheus
       annotations:
-        kubernetes.io/ingress.class: kong
+        kubernetes.io/ingress.class: none
       labels:
         global: "true"
     plugin: prometheus

--- a/tests/performance/suites/keyauth/helpers_test.go
+++ b/tests/performance/suites/keyauth/helpers_test.go
@@ -1,0 +1,296 @@
+package keyauth
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/giantswarm/apptest-framework/v5/pkg/state"
+	"github.com/giantswarm/clustertest/v5/pkg/application"
+	"github.com/giantswarm/clustertest/v5/pkg/logger"
+
+	cmv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func createWorkloadClusterNamespace(name string) {
+	wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
+	Expect(err).NotTo(HaveOccurred())
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	Eventually(func() error {
+		err := wcClient.Create(state.GetContext(), ns)
+		if err == nil || errors.IsAlreadyExists(err) {
+			return nil
+		}
+		logger.Log("Create namespace %s failed, will retry: %v", name, err)
+		return err
+	}).
+		WithTimeout(5 * time.Minute).
+		WithPolling(5 * time.Second).
+		Should(Succeed())
+}
+
+func getWorkloadClusterBaseDomain() string {
+	values := &application.ClusterValues{}
+	err := state.GetFramework().MC().GetHelmValues(state.GetCluster().Name, state.GetCluster().GetNamespace(), values)
+	Expect(err).NotTo(HaveOccurred())
+
+	if values.BaseDomain == "" {
+		Fail("baseDomain field missing from cluster helm values")
+	}
+
+	return fmt.Sprintf("%s.%s", state.GetCluster().Name, values.BaseDomain)
+}
+
+func newHttpClientWithProxy(endpoint string) *http.Client {
+	httpProxy := os.Getenv("HTTP_PROXY")
+	noProxy := os.Getenv("NO_PROXY")
+	useProxy := httpProxy != "" && !endpointMatchesNoProxy(endpoint, noProxy)
+
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			dialer := &net.Dialer{
+				Resolver: &net.Resolver{
+					PreferGo: true,
+					Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+						if useProxy {
+							u, err := url.Parse(httpProxy)
+							if err != nil {
+								logger.Log("Error parsing HTTP_PROXY as a URL %s", httpProxy)
+							} else {
+								if addr == u.Host {
+									// always use coredns for proxy address resolution.
+									var d net.Dialer
+									return d.Dial(network, address)
+								}
+							}
+						}
+						d := net.Dialer{
+							Timeout: time.Millisecond * time.Duration(10000),
+						}
+						return d.DialContext(ctx, "udp", "8.8.4.4:53")
+					},
+				},
+			}
+			return dialer.DialContext(ctx, network, addr)
+		},
+	}
+
+	if useProxy {
+		logger.Log("Detected need to use PROXY as HTTP_PROXY env var was set to %s", httpProxy)
+		transport.Proxy = http.ProxyFromEnvironment
+	} else if httpProxy != "" {
+		logger.Log("Skipping HTTP_PROXY %s for endpoint %s because it matches NO_PROXY=%s", httpProxy, endpoint, noProxy)
+	}
+
+	httpClient := &http.Client{
+		Transport: transport,
+	}
+	return httpClient
+}
+
+func endpointMatchesNoProxy(endpoint, noProxy string) bool {
+	if noProxy == "" {
+		return false
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return false
+	}
+	host := u.Hostname()
+	if host == "" {
+		return false
+	}
+	for entry := range strings.SplitSeq(noProxy, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		if entry == "*" {
+			return true
+		}
+		entry = strings.TrimPrefix(entry, ".")
+		if host == entry || strings.HasSuffix(host, "."+entry) {
+			return true
+		}
+	}
+	return false
+}
+
+func deploymentReadyInNamespace(namespace string) (bool, error) {
+	wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
+	if err != nil {
+		return false, err
+	}
+
+	logger.Log("Checking for ready deployments in namespace %s", namespace)
+	deployments := &appsv1.DeploymentList{}
+	err = wcClient.List(state.GetContext(), deployments, client.InNamespace(namespace))
+	if err != nil {
+		return false, err
+	}
+
+	for i := range deployments.Items {
+		dep := &deployments.Items[i]
+		if dep.Spec.Replicas == nil {
+			continue
+		}
+		desired := *dep.Spec.Replicas
+		if desired > 0 && dep.Status.ReadyReplicas == desired && dep.Status.AvailableReplicas == desired {
+			logger.Log("Deployment %s/%s is ready (%d/%d replicas)", namespace, dep.Name, dep.Status.ReadyReplicas, desired)
+			return true, nil
+		}
+	}
+
+	logger.Log("No ready deployment found in namespace %s", namespace)
+	return false, nil
+}
+
+func loadBalancerServiceReadyInNamespace(namespace string) (bool, error) {
+	wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
+	if err != nil {
+		return false, err
+	}
+
+	logger.Log("Checking for ready LoadBalancer services in namespace %s", namespace)
+	services := &corev1.ServiceList{}
+	err = wcClient.List(state.GetContext(), services, client.InNamespace(namespace))
+	if err != nil {
+		return false, err
+	}
+
+	for i := range services.Items {
+		svc := &services.Items[i]
+		if svc.Spec.Type == corev1.ServiceTypeLoadBalancer {
+			if len(svc.Status.LoadBalancer.Ingress) > 0 &&
+				(svc.Status.LoadBalancer.Ingress[0].Hostname != "" || svc.Status.LoadBalancer.Ingress[0].IP != "") {
+				logger.Log("LoadBalancer service %s/%s is ready with address: %s%s",
+					namespace, svc.Name, svc.Status.LoadBalancer.Ingress[0].Hostname, svc.Status.LoadBalancer.Ingress[0].IP)
+				return true, nil
+			}
+		}
+	}
+
+	logger.Log("No ready LoadBalancer service found in namespace %s", namespace)
+	return false, nil
+}
+
+func allCertificatesReady(expected []types.NamespacedName) (bool, error) {
+	wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
+	if err != nil {
+		return false, err
+	}
+
+	logger.Log("Listing all certificates on the workload cluster")
+	certs := &cmv1.CertificateList{}
+	if err := wcClient.List(state.GetContext(), certs); err != nil {
+		return false, err
+	}
+
+	present := make(map[types.NamespacedName]struct{}, len(certs.Items))
+	for i := range certs.Items {
+		cert := &certs.Items[i]
+		present[types.NamespacedName{Namespace: cert.Namespace, Name: cert.Name}] = struct{}{}
+	}
+	for _, key := range expected {
+		if _, ok := present[key]; !ok {
+			logger.Log("Expected certificate %s not found yet", key)
+			return false, nil
+		}
+	}
+
+	for i := range certs.Items {
+		cert := &certs.Items[i]
+		ready := false
+		for _, condition := range cert.Status.Conditions {
+			if condition.Type == cmv1.CertificateConditionReady && condition.Status == cmmeta.ConditionTrue {
+				ready = true
+				break
+			}
+		}
+		if !ready {
+			logger.Log("Certificate %s/%s not ready yet", cert.Namespace, cert.Name)
+			return false, nil
+		}
+	}
+
+	logger.Log("All %d certificates are ready", len(certs.Items))
+	return true, nil
+}
+
+func crdExists(name string) (bool, error) {
+	wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
+	if err != nil {
+		return false, err
+	}
+
+	logger.Log("Checking if CRD %s exists", name)
+	crd := &unstructured.Unstructured{}
+	crd.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "apiextensions.k8s.io",
+		Version: "v1",
+		Kind:    "CustomResourceDefinition",
+	})
+	err = wcClient.Get(state.GetContext(), client.ObjectKey{Name: name}, crd)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Log("CRD %s not found yet", name)
+			return false, nil
+		}
+		return false, err
+	}
+
+	logger.Log("CRD %s exists", name)
+	return true, nil
+}
+
+func expectEndpointServesTraffic(endpoint string) {
+	httpClient := newHttpClientWithProxy(endpoint)
+	Eventually(func() (string, error) {
+		logger.Log("Trying to get a successful response from %s", endpoint)
+		resp, err := httpClient.Get(endpoint)
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			logger.Log("Was expecting status code '%d' but actually got '%d'", http.StatusOK, resp.StatusCode)
+			return "", err
+		}
+
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			logger.Log("Was not expecting the response body to be empty")
+			return "", err
+		}
+
+		return string(bodyBytes), nil
+	}).
+		WithTimeout(15 * time.Minute).
+		WithPolling(5 * time.Second).
+		Should(ContainSubstring("Online Boutique"))
+}

--- a/tests/performance/suites/keyauth/k6_helpers_test.go
+++ b/tests/performance/suites/keyauth/k6_helpers_test.go
@@ -1,0 +1,380 @@
+package keyauth
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/giantswarm/apptest-framework/v5/pkg/state"
+	"github.com/giantswarm/clustertest/v5/pkg/client"
+	"github.com/giantswarm/clustertest/v5/pkg/logger"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	cr "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// testRunGone is the sentinel stage returned by getTestRunStage when the
+// TestRun CR no longer exists (typically because k6-operator cleaned it up
+// after completion with cleanup: post).
+const testRunGone = "gone"
+
+const defaultK6KubeconfigPath = "/etc/k6-kubeconfig"
+
+// prometheusCredentialsSecret is the secret that the k6 runner reads via
+// envFrom to authenticate against the Prometheus remote-write endpoint. It is
+// populated by mirrorPrometheusCredentials from kube-system/alloy-metrics on
+// the management cluster
+const prometheusCredentialsSecret = "k6-prometheus-rw-credentials"
+
+// prometheusOffEnvVar disables the Prometheus remote-write integration on the
+// e2e TestRun when set to a truthy value. Useful for local dev runs that don't
+// have permission to read kube-system/alloy-metrics on the MC.
+const prometheusOffEnvVar = "E2E_K6_PROMETHEUS_OFF"
+
+func prometheusEnabled() bool {
+	v := os.Getenv(prometheusOffEnvVar)
+	return v == "" || v == "0" || v == "false"
+}
+
+// k6Client is a cached Kubernetes client built from E2E_K6_KUBECONFIG. The
+// suite no longer applies the TestRun via this client — that now goes onto
+// the MC — but the helpers are kept for any out-of-tree caller that still
+// wants to talk to a separate k6 cluster.
+var k6Client *client.Client
+
+func getK6KubeconfigPath() string {
+	if p := os.Getenv("E2E_K6_KUBECONFIG"); p != "" {
+		return p
+	}
+	return defaultK6KubeconfigPath
+}
+
+// getK6Client returns a cached Kubernetes client for the k6 cluster.
+// It reads the kubeconfig from E2E_K6_KUBECONFIG (default: /etc/k6-kubeconfig).
+// Kept for reference / future use; the e2e suite itself talks to the MC.
+func getK6Client() *client.Client {
+	if k6Client != nil {
+		return k6Client
+	}
+
+	kubeconfigPath := getK6KubeconfigPath()
+	logger.Log("Creating k6 cluster client from kubeconfig at %s", kubeconfigPath)
+
+	var err error
+	k6Client, err = client.New(kubeconfigPath)
+	Expect(err).NotTo(HaveOccurred(), "failed to create k6 cluster client from %s", kubeconfigPath)
+
+	return k6Client
+}
+
+func getK6Namespace() string {
+	ns := os.Getenv("E2E_K6_NAMESPACE")
+	if ns == "" {
+		return "k6-operator"
+	}
+	return ns
+}
+
+func envOrDefault(key, fallback string) string {
+	loadConfigEnv()
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func buildScenarioConfigMap(name, namespace string) *corev1.ConfigMap {
+	_, thisFile, _, ok := runtime.Caller(0)
+	Expect(ok).To(BeTrue(), "failed to resolve test file path")
+
+	// Read the canonical scenario script from the suite-local
+	// test_data/test-scenario.js, relative to this Go file.
+	scenarioPath := filepath.Join(filepath.Dir(thisFile), "test_data", "test-scenario.js")
+	content, err := os.ReadFile(scenarioPath)
+	Expect(err).NotTo(HaveOccurred(), "failed to read test-scenario.js at %s", scenarioPath)
+
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			"test-scenario.js": string(content),
+		},
+	}
+}
+
+func securityContext() map[string]any {
+	return map[string]any{
+		"fsGroup":      int64(1000),
+		"runAsGroup":   int64(1000),
+		"runAsNonRoot": true,
+		"runAsUser":    int64(1000),
+		"seccompProfile": map[string]any{
+			"type": "RuntimeDefault",
+		},
+	}
+}
+
+func containerSecurityContext() map[string]any {
+	return map[string]any{
+		"runAsNonRoot":             true,
+		"runAsUser":                int64(1000),
+		"runAsGroup":               int64(1000),
+		"readOnlyRootFilesystem":   false,
+		"allowPrivilegeEscalation": false,
+		"capabilities": map[string]any{
+			"drop": []any{"ALL"},
+		},
+		"seccompProfile": map[string]any{
+			"type": "RuntimeDefault",
+		},
+	}
+}
+
+func buildTestRunUnstructured(name, namespace, configMapName, baseDomain, testID string) *unstructured.Unstructured {
+	image := envOrDefault("K6_IMAGE", "gsoci.azurecr.io/giantswarm/k6:1.6.0")
+
+	env := []any{
+		map[string]any{"name": "ENDPOINTS", "value": envOrDefault("ENDPOINTS", "10")},
+		map[string]any{"name": "BASE_DOMAIN", "value": baseDomain},
+		map[string]any{"name": "SCENARIO_DURATION_SECONDS", "value": envOrDefault("SCENARIO_DURATION_SECONDS", "1200")},
+		map[string]any{"name": "WAIT_BETWEEN_SCENARIOS", "value": envOrDefault("WAIT_BETWEEN_SCENARIOS", "300")},
+		map[string]any{"name": "PEAK_HTTP_RPS", "value": envOrDefault("PEAK_HTTP_RPS", "50")},
+		map[string]any{"name": "RAMP_STEP_HTTP_RPS", "value": envOrDefault("RAMP_STEP_HTTP_RPS", "10")},
+		map[string]any{"name": "RAMP_STEP_DURATION_SECONDS", "value": envOrDefault("RAMP_STEP_DURATION_SECONDS", "300")},
+		map[string]any{"name": "PRE_ALLOCATED_VUS", "value": envOrDefault("PRE_ALLOCATED_VUS", "50")},
+		map[string]any{"name": "MAX_VUS", "value": envOrDefault("MAX_VUS", "150")},
+		map[string]any{"name": "GRACEFUL_STOP", "value": envOrDefault("GRACEFUL_STOP", "30s")},
+		map[string]any{"name": "SLO_P95_LATENCY_MS", "value": envOrDefault("SLO_P95_LATENCY_MS", "500")},
+		map[string]any{"name": "SLO_P99_LATENCY_MS", "value": envOrDefault("SLO_P99_LATENCY_MS", "1000")},
+		map[string]any{"name": "SLO_ERROR_RATE", "value": envOrDefault("SLO_ERROR_RATE", "0.001")},
+		map[string]any{"name": "SLO_CHECKS_RATE", "value": envOrDefault("SLO_CHECKS_RATE", "0.95")},
+		// API key the scenario sends on the "valid key" request; must match what
+		// enforceEnvoyKeyAuth / enforceKongKeyAuth provisions on the gateways.
+		map[string]any{"name": "API_KEY", "value": apiKey()},
+	}
+
+	runner := map[string]any{
+		"image":                    image,
+		"env":                      env,
+		"containerSecurityContext": containerSecurityContext(),
+		"securityContext":          securityContext(),
+	}
+
+	spec := map[string]any{
+		"parallelism": int64(4),
+		"quiet":       "false",
+		"separate":    false,
+		"script": map[string]any{
+			"configMap": map[string]any{
+				"name": configMapName,
+				"file": "test-scenario.js",
+			},
+		},
+		"initializer": map[string]any{
+			"image":                    image,
+			"containerSecurityContext": containerSecurityContext(),
+			"securityContext":          securityContext(),
+		},
+		"starter": map[string]any{
+			"containerSecurityContext": containerSecurityContext(),
+			"securityContext":          securityContext(),
+		},
+	}
+
+	if prometheusEnabled() {
+		// Push metrics to Mimir so e2e runs show up in Grafana under the testID
+		// series — matches envoy-loadtesting/k6/testrun.yaml.
+		spec["arguments"] = fmt.Sprintf("-o experimental-prometheus-rw --tag testid=%s", testID)
+		runner["envFrom"] = []any{
+			map[string]any{
+				"secretRef": map[string]any{
+					"name": prometheusCredentialsSecret,
+				},
+			},
+		}
+		env = append(env,
+			map[string]any{"name": "K6_PROMETHEUS_RW_SERVER_URL", "value": envOrDefault("PROMETHEUS_RW_URL", "http://mimir-gateway.mimir.svc.cluster.local/api/v1/push")},
+			map[string]any{"name": "K6_PROMETHEUS_RW_HTTP_HEADERS", "value": envOrDefault("K6_PROMETHEUS_RW_HTTP_HEADERS", "X-Scope-OrgID:giantswarm")},
+			map[string]any{"name": "K6_PROMETHEUS_RW_PUSH_INTERVAL", "value": envOrDefault("PROMETHEUS_RW_PUSH_INTERVAL", "5s")},
+		)
+		runner["env"] = env
+	}
+
+	spec["runner"] = runner
+
+	testRun := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "k6.io/v1alpha1",
+			"kind":       "TestRun",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": spec,
+		},
+	}
+
+	testRun.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "k6.io",
+		Version: "v1alpha1",
+		Kind:    "TestRun",
+	})
+
+	return testRun
+}
+
+// mirrorPrometheusCredentials reads the alloy-metrics credentials from the
+// management cluster's kube-system namespace and writes them into the k6
+// namespace (also on the MC) under prometheusCredentialsSecret. The runner
+// reads them via envFrom to talk to the Prometheus remote-write endpoint.
+// Mirrors envoy-loadtesting/deploy.sh.
+func mirrorPrometheusCredentials(namespace string) {
+	ctx := state.GetContext()
+	mc := state.GetFramework().MC()
+
+	src := &corev1.Secret{}
+	err := mc.Get(ctx, cr.ObjectKey{Name: "alloy-metrics", Namespace: "kube-system"}, src)
+	Expect(err).NotTo(HaveOccurred(), "failed to read kube-system/alloy-metrics on the MC - set %s=true to skip Prometheus push", prometheusOffEnvVar)
+
+	username, ok := src.Data["metrics-username"]
+	Expect(ok).To(BeTrue(), "kube-system/alloy-metrics is missing the metrics-username key")
+	password, ok := src.Data["metrics-password"]
+	Expect(ok).To(BeTrue(), "kube-system/alloy-metrics is missing the metrics-password key")
+
+	dst := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      prometheusCredentialsSecret,
+			Namespace: namespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"K6_PROMETHEUS_RW_USERNAME": username,
+			"K6_PROMETHEUS_RW_PASSWORD": password,
+		},
+	}
+
+	// Best-effort delete-then-create so a partial / stale secret from a
+	// previous run doesn't trip up the runner.
+	_ = mc.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: prometheusCredentialsSecret, Namespace: namespace}})
+	err = mc.Create(ctx, dst)
+	Expect(err).NotTo(HaveOccurred(), "failed to create %s/%s on the MC", namespace, prometheusCredentialsSecret)
+
+	logger.Log("Mirrored alloy-metrics credentials into %s/%s", namespace, prometheusCredentialsSecret)
+}
+
+func getTestRunStage(name, namespace string) (string, error) {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "k6.io",
+		Version: "v1alpha1",
+		Kind:    "TestRun",
+	})
+
+	err := state.GetFramework().MC().Get(state.GetContext(), cr.ObjectKey{Name: name, Namespace: namespace}, obj)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Log("TestRun %s/%s no longer exists (cleaned up by operator)", namespace, name)
+			return testRunGone, nil
+		}
+		return "", err
+	}
+
+	stage, found, err := unstructured.NestedString(obj.Object, "status", "stage")
+	if err != nil || !found {
+		logger.Log("TestRun %s/%s stage not yet populated", namespace, name)
+		return "", nil
+	}
+
+	logger.Log("TestRun %s/%s stage: %s", namespace, name, stage)
+	return stage, nil
+}
+
+// assertTestRunSuccess verifies the TestRun finished successfully. If the
+// TestRun CR has been deleted (operator cleanup after completion), it falls
+// back to fallbackStage — the last stage observed during polling — so we can
+// still distinguish a clean finish from a deletion after an error.
+func assertTestRunSuccess(name, namespace, fallbackStage string) {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "k6.io",
+		Version: "v1alpha1",
+		Kind:    "TestRun",
+	})
+
+	err := state.GetFramework().MC().Get(state.GetContext(), cr.ObjectKey{Name: name, Namespace: namespace}, obj)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Log("TestRun %s/%s was cleaned up; asserting on last observed stage: %q", namespace, name, fallbackStage)
+			Expect(fallbackStage).To(Equal("finished"), "TestRun did not finish successfully before cleanup, last observed stage: %q", fallbackStage)
+			return
+		}
+		Expect(err).NotTo(HaveOccurred(), "failed to get TestRun for assertion")
+	}
+
+	stage, _, _ := unstructured.NestedString(obj.Object, "status", "stage")
+	Expect(stage).To(Equal("finished"), "TestRun did not finish successfully, stage: %s", stage)
+
+	// Log conditions for diagnostics
+	conditions, found, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if found {
+		for _, c := range conditions {
+			if cond, ok := c.(map[string]any); ok {
+				logger.Log("TestRun condition: type=%v status=%v reason=%v message=%v",
+					cond["type"], cond["status"], cond["reason"], cond["message"])
+			}
+		}
+	}
+}
+
+func cleanupK6Resources(testRunName, configMapName, namespace string) {
+	ctx := state.GetContext()
+	mc := state.GetFramework().MC()
+
+	// Delete TestRun
+	testRun := &unstructured.Unstructured{}
+	testRun.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "k6.io",
+		Version: "v1alpha1",
+		Kind:    "TestRun",
+	})
+	testRun.SetName(testRunName)
+	testRun.SetNamespace(namespace)
+	if err := mc.Delete(ctx, testRun); err != nil {
+		logger.Log("Cleanup: failed to delete TestRun %s/%s (may not exist): %v", namespace, testRunName, err)
+	}
+
+	// Delete ConfigMap
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: namespace,
+		},
+	}
+	if err := mc.Delete(ctx, cm); err != nil {
+		logger.Log("Cleanup: failed to delete ConfigMap %s/%s (may not exist): %v", namespace, configMapName, err)
+	}
+
+	// Delete Prometheus credentials secret so the next run mirrors fresh creds
+	credSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      prometheusCredentialsSecret,
+			Namespace: namespace,
+		},
+	}
+	if err := mc.Delete(ctx, credSecret); err != nil {
+		logger.Log("Cleanup: failed to delete Secret %s/%s (may not exist): %v", namespace, prometheusCredentialsSecret, err)
+	}
+
+	// Give the operator a moment to process the deletion
+	time.Sleep(5 * time.Second)
+}

--- a/tests/performance/suites/keyauth/performance_suite_test.go
+++ b/tests/performance/suites/keyauth/performance_suite_test.go
@@ -30,6 +30,9 @@ const (
 // stands in for the source file's ${WC}.${BASE_DOMAIN} (the test framework
 // already hands us the concatenated FQDN as baseDomain).
 const microservicesDemoAppValuesTmpl = `
+images:
+  tag: v0.10.5
+
 ingress:
   enabled: ${INGRESS_NGINX_ENABLED}
   number: ${PUBLIC_ENDPOINTS}

--- a/tests/performance/suites/keyauth/performance_suite_test.go
+++ b/tests/performance/suites/keyauth/performance_suite_test.go
@@ -1,0 +1,477 @@
+package keyauth
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/giantswarm/apptest-framework/v5/pkg/state"
+	"github.com/giantswarm/apptest-framework/v5/pkg/suite"
+	"github.com/giantswarm/clustertest/v5/pkg/application"
+	"github.com/giantswarm/clustertest/v5/pkg/logger"
+	"github.com/giantswarm/clustertest/v5/pkg/wait"
+)
+
+const (
+	isUpgrade = false
+
+	proxyControllerKong = "kong"
+)
+
+// microservicesDemoAppValuesTmpl mirrors
+// envoy-loadtesting/wc-deployment/values/microservices-demo.yaml. ${BASE}
+// stands in for the source file's ${WC}.${BASE_DOMAIN} (the test framework
+// already hands us the concatenated FQDN as baseDomain).
+const microservicesDemoAppValuesTmpl = `
+ingress:
+  enabled: ${INGRESS_NGINX_ENABLED}
+  number: ${PUBLIC_ENDPOINTS}
+  base: ${BASE}
+  host: nginx-onlineboutique
+
+kong:
+  enabled: ${KONG_ENABLED}
+  number: ${PUBLIC_ENDPOINTS}
+  base: ${BASE}
+  host: kong-onlineboutique
+  ingressCname: kong-ingress.${BASE}
+
+httproute:
+  enabled: true
+  base: ${BASE}
+  hostname: onlineboutique
+  namespaces:
+    create: true
+    number: ${PUBLIC_ENDPOINTS}
+
+adService:
+  resources:
+    requests:
+      cpu: 200m
+      memory: 180Mi
+    limits:
+      cpu: 300m
+      memory: 300Mi
+  hpa:
+    enabled: true
+    minReplicas: ${HPA_MIN_REPLICAS}
+    maxReplicas: ${HPA_MAX_REPLICAS}
+    targetCPUUtilizationPercentage: 80
+
+cartService:
+  resources:
+    requests:
+      cpu: 200m
+      memory: 128Mi
+    limits:
+      cpu: 300m
+      memory: 256Mi
+  hpa:
+    enabled: true
+    minReplicas: ${HPA_MIN_REPLICAS}
+    maxReplicas: ${HPA_MAX_REPLICAS}
+    targetCPUUtilizationPercentage: 80
+
+checkoutService:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+  hpa:
+    enabled: true
+    minReplicas: ${HPA_MIN_REPLICAS}
+    maxReplicas: ${HPA_MAX_REPLICAS}
+    targetCPUUtilizationPercentage: 80
+
+currencyService:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+  hpa:
+    enabled: true
+    minReplicas: ${HPA_MIN_REPLICAS}
+    maxReplicas: ${HPA_MAX_REPLICAS}
+    targetCPUUtilizationPercentage: 80
+
+emailService:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+  hpa:
+    enabled: true
+    minReplicas: ${HPA_MIN_REPLICAS}
+    maxReplicas: ${HPA_MAX_REPLICAS}
+    targetCPUUtilizationPercentage: 80
+
+frontend:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+  hpa:
+    enabled: true
+    minReplicas: ${HPA_MIN_REPLICAS}
+    maxReplicas: ${HPA_MAX_REPLICAS}
+    targetCPUUtilizationPercentage: 80
+
+loadGenerator:
+  resources:
+    requests:
+      cpu: 300m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+paymentService:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+  hpa:
+    enabled: true
+    minReplicas: ${HPA_MIN_REPLICAS}
+    maxReplicas: ${HPA_MAX_REPLICAS}
+    targetCPUUtilizationPercentage: 80
+
+productCatalogService:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+  hpa:
+    enabled: true
+    minReplicas: ${HPA_MIN_REPLICAS}
+    maxReplicas: ${HPA_MAX_REPLICAS}
+    targetCPUUtilizationPercentage: 80
+
+recommendationService:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 220Mi
+    limits:
+      cpu: 200m
+      memory: 450Mi
+  hpa:
+    enabled: true
+    minReplicas: ${HPA_MIN_REPLICAS}
+    maxReplicas: ${HPA_MAX_REPLICAS}
+    targetCPUUtilizationPercentage: 80
+
+shippingService:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+  hpa:
+    enabled: true
+    minReplicas: ${HPA_MIN_REPLICAS}
+    maxReplicas: ${HPA_MAX_REPLICAS}
+    targetCPUUtilizationPercentage: 80
+`
+
+// buildMicroservicesDemoAppValues returns the values overlay applied to the
+// microservices-demo-app dependency. Mirrors
+// envoy-loadtesting/wc-deployment/values/microservices-demo.yaml; the
+// PUBLIC_ENDPOINTS / HPA_MIN_REPLICAS / HPA_MAX_REPLICAS knobs are read via
+// envOrDefault so config.env (loaded by loadConfigEnv) supplies the same
+// defaults as the manual pipeline. Only the chosen ingress controller branch
+// is enabled.
+func buildMicroservicesDemoAppValues(baseDomain string) string {
+	// This suite only compares against Kong (see resolveProxyController), so the
+	// nginx ingress branch of the chart stays disabled.
+	vars := map[string]string{
+		"INGRESS_NGINX_ENABLED": "false",
+		"KONG_ENABLED":          "true",
+		"BASE":                  baseDomain,
+		"PUBLIC_ENDPOINTS":      envOrDefault("PUBLIC_ENDPOINTS", "10"),
+		"HPA_MIN_REPLICAS":      envOrDefault("HPA_MIN_REPLICAS", "1"),
+		"HPA_MAX_REPLICAS":      envOrDefault("HPA_MAX_REPLICAS", "20"),
+	}
+	return os.Expand(microservicesDemoAppValuesTmpl, func(key string) string {
+		return vars[key]
+	})
+}
+
+func TestPerformance(t *testing.T) {
+	suite.New().
+		// envoy-gateway is the SUT; the framework installs it via the
+		// gateway-api-bundle so the gateway-api CRDs and the default
+		// Gateway/HTTPRoute config come up at the same time. Bundle-level
+		// values (ListenerSet, listeners, TLS issuer) live in
+		// bundle_values.yaml.
+		InAppBundle("gateway-api-bundle").
+		WithInstallNamespace("envoy-gateway-system").
+		WithIsUpgrade(isUpgrade).
+		WithValuesFile("./values.yaml").
+		WithBundleValuesFile("./bundle_values.yaml").
+		AfterClusterReady(func() {
+			var (
+				awsLBApp *application.Application
+				kongApp  *application.Application
+			)
+
+			It("should create the loadtesting namespace", FlakeAttempts(3), func() {
+				createWorkloadClusterNamespace("loadtesting")
+			})
+
+			It("should install aws-load-balancer-controller", FlakeAttempts(3), func() {
+				mcName := state.GetFramework().MC().GetClusterName()
+				clusterName := state.GetCluster().Name
+				awsLBApp = deployDependency("aws-lb-controller-bundle", fmt.Sprintf(awsLBControllerBundleValues, mcName, clusterName, clusterName))
+			})
+
+			It("should wait for aws-load-balancer-controller to be ready", FlakeAttempts(3), func() {
+				waitForDependency(awsLBApp)
+			})
+
+			It("should install kong-app", FlakeAttempts(3), func() {
+				baseDomain := getWorkloadClusterBaseDomain()
+				kongApp = deployDependency("kong-app", fmt.Sprintf(kongAppValues, baseDomain), "kong")
+				waitForDependency(kongApp)
+			})
+
+			It("should configure kong prometheus plugin", FlakeAttempts(3), func() {
+				By("Waiting for KongClusterPlugin CRD to be registered")
+				Eventually(func() (bool, error) {
+					return crdExists("kongclusterplugins.configuration.konghq.com")
+				}).
+					WithTimeout(5 * time.Minute).
+					WithPolling(10 * time.Second).
+					Should(BeTrue())
+
+				By("Adding extraObjects config to kong-app via spec.extraConfigs")
+				clusterName := state.GetCluster().Name
+				addExtraConfigToApp(
+					fmt.Sprintf("%s-kong-app", clusterName),
+					fmt.Sprintf("%s-kong-extra-objects", clusterName),
+					kongExtraObjectsValues,
+				)
+			})
+		}).
+		Tests(func() {
+			var (
+				microservicesDemoApp *application.Application
+				envoyUrl             string
+				kongUrl              string
+			)
+			BeforeEach(func() {
+				envoyUrl = fmt.Sprintf("https://onlineboutique.loadtesting-0.%s", getWorkloadClusterBaseDomain())
+				// Kong runs as a Gateway API implementation: the chart exposes a
+				// single HTTPRoute host (no per-endpoint fan-out like Envoy).
+				kongUrl = fmt.Sprintf("https://kong-onlineboutique.loadtesting.%s", getWorkloadClusterBaseDomain())
+			})
+
+			It("should have deployed envoy-gateway via the gateway-api-bundle", func() {
+				bundleApp := state.GetBundleApplication()
+				Expect(bundleApp).NotTo(BeNil())
+
+				Eventually(wait.IsAppDeployed(state.GetContext(), state.GetFramework().MC(), bundleApp.InstallName, bundleApp.GetNamespace())).
+					WithTimeout(15 * time.Minute).
+					WithPolling(5 * time.Second).
+					Should(BeTrue())
+
+				Eventually(func() (bool, error) {
+					done, err := wait.IsAppDeployed(state.GetContext(), state.GetFramework().MC(), state.GetApplication().InstallName, state.GetApplication().Organization.GetNamespace())()
+					if err != nil {
+						if errors.IsNotFound(err) {
+							logger.Log("App '%s/%s' doesn't exist yet", state.GetApplication().Organization.GetNamespace(), state.GetApplication().InstallName)
+							return false, nil
+						}
+						return false, err
+					}
+					return done, nil
+				}).
+					WithTimeout(15 * time.Minute).
+					WithPolling(5 * time.Second).
+					Should(BeTrue())
+			})
+
+			It("should have gateway api CRDs registered", func() {
+				for _, crd := range []string{
+					"gateways.gateway.networking.k8s.io",
+					"httproutes.gateway.networking.k8s.io",
+					"listenersets.gateway.networking.k8s.io",
+				} {
+					Eventually(func() (bool, error) {
+						return crdExists(crd)
+					}).
+						WithTimeout(5 * time.Minute).
+						WithPolling(10 * time.Second).
+						Should(BeTrue())
+				}
+			})
+
+			It("should have ready dependency deployments on the workload cluster", func() {
+				namespaces := []string{"aws-load-balancer-controller", "envoy-gateway-system", "kong"}
+				for _, ns := range namespaces {
+					Eventually(func() (bool, error) {
+						return deploymentReadyInNamespace(ns)
+					}).
+						WithTimeout(10 * time.Minute).
+						WithPolling(5 * time.Second).
+						Should(BeTrue())
+				}
+			})
+
+			It("should install and wait for microservices-demo-app", func() {
+				baseDomain := getWorkloadClusterBaseDomain()
+				microservicesDemoApp = deployDependency("microservices-demo-app", buildMicroservicesDemoAppValues(baseDomain), "loadtesting")
+				waitForDependency(microservicesDemoApp)
+			})
+
+			It("should have ready LoadBalancer services on the workload cluster", func() {
+				namespaces := []string{"envoy-gateway-system", "kong"}
+				for _, ns := range namespaces {
+					Eventually(func() (bool, error) {
+						return loadBalancerServiceReadyInNamespace(ns)
+					}).
+						WithTimeout(10 * time.Minute).
+						WithPolling(10 * time.Second).
+						Should(BeTrue())
+				}
+			})
+
+			It("should have ready certificates on the workload cluster", func() {
+				expected := []types.NamespacedName{
+					{Namespace: "loadtesting-0", Name: "gateway-0-https"},
+					{Namespace: "loadtesting", Name: "frontend-kong-wildcard"},
+				}
+
+				Eventually(func() (bool, error) {
+					return allCertificatesReady(expected)
+				}).
+					WithTimeout(20 * time.Minute).
+					WithPolling(5 * time.Second).
+					Should(BeTrue())
+			})
+			It("should serve traffic from envoy gateway", func() {
+				DeferCleanup(func() {
+					if CurrentSpecReport().Failed() {
+						AbortSuite("envoy gateway failed to serve traffic, aborting remaining tests")
+					}
+				})
+				expectEndpointServesTraffic(envoyUrl)
+			})
+			It("should serve traffic from kong", func() {
+				DeferCleanup(func() {
+					if CurrentSpecReport().Failed() {
+						AbortSuite("kong failed to serve traffic, aborting remaining tests")
+					}
+				})
+				expectEndpointServesTraffic(kongUrl)
+			})
+
+			// With the unauthenticated baseline confirmed above, enforce API key
+			// auth at each gateway and verify it before load testing the
+			// authenticated path. The k6 key-auth scenario then asserts
+			// valid->200, wrong->401, missing->401 under load.
+			It("should enforce api key auth on the envoy gateway", FlakeAttempts(3), func() {
+				enforceEnvoyKeyAuth()
+			})
+			It("should enforce api key auth on kong", FlakeAttempts(3), func() {
+				enforceKongKeyAuth()
+			})
+			It("should require an api key on envoy gateway", func() {
+				DeferCleanup(func() {
+					if CurrentSpecReport().Failed() {
+						AbortSuite("envoy gateway api key auth not enforced, aborting remaining tests")
+					}
+				})
+				expectEndpointRequiresKey(envoyUrl)
+			})
+			It("should require an api key on kong", func() {
+				DeferCleanup(func() {
+					if CurrentSpecReport().Failed() {
+						AbortSuite("kong api key auth not enforced, aborting remaining tests")
+					}
+				})
+				expectEndpointRequiresKey(kongUrl)
+			})
+			It("should run k6 load tests successfully", func() {
+				k6Namespace := getK6Namespace()
+				baseDomain := getWorkloadClusterBaseDomain()
+				testRunName := fmt.Sprintf("e2e-load-test-%s", state.GetCluster().Name)
+				configMapName := fmt.Sprintf("e2e-load-test-scenario-%s", state.GetCluster().Name)
+				testID := envOrDefault("K6_TEST_ID", testRunName)
+
+				// Clean up any stale resources from a previous interrupted run
+				cleanupK6Resources(testRunName, configMapName, k6Namespace)
+
+				if prometheusEnabled() {
+					By("Mirroring alloy-metrics credentials into the k6 namespace")
+					mirrorPrometheusCredentials(k6Namespace)
+				}
+
+				By("Creating test scenario ConfigMap on the MC")
+				cm := buildScenarioConfigMap(configMapName, k6Namespace)
+				err := state.GetFramework().MC().Create(state.GetContext(), cm)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Creating TestRun on the MC")
+				testRun := buildTestRunUnstructured(testRunName, k6Namespace, configMapName, baseDomain, testID)
+				err = state.GetFramework().MC().Create(state.GetContext(), testRun)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Waiting for TestRun to complete")
+				var lastStage string
+				Eventually(func() (string, error) {
+					stage, err := getTestRunStage(testRunName, k6Namespace)
+					if err != nil {
+						return "", err
+					}
+					if stage != "" && stage != testRunGone {
+						lastStage = stage
+					}
+					return stage, nil
+				}).
+					WithTimeout(120 * time.Minute).
+					WithPolling(30 * time.Second).
+					Should(BeElementOf("finished", "error", testRunGone))
+
+				By("Asserting TestRun succeeded")
+				assertTestRunSuccess(testRunName, k6Namespace, lastStage)
+
+				By("Cleaning up k6 resources")
+				cleanupK6Resources(testRunName, configMapName, k6Namespace)
+			})
+		}).
+		AfterSuite(func() {
+			k6Namespace := getK6Namespace()
+			testRunName := fmt.Sprintf("e2e-load-test-%s", state.GetCluster().Name)
+			configMapName := fmt.Sprintf("e2e-load-test-scenario-%s", state.GetCluster().Name)
+			cleanupK6Resources(testRunName, configMapName, k6Namespace)
+		}).
+		Run(t, "Key Auth Performance Test")
+}

--- a/tests/performance/suites/keyauth/test_data/cluster_values.yaml
+++ b/tests/performance/suites/keyauth/test_data/cluster_values.yaml
@@ -7,6 +7,8 @@ global:
           enableGatewayAPI: true
           kind: ControllerConfiguration
   connectivity:
+    dns:
+      wildcardCnameTarget: gateway
     certManager:
       useDnsChallenges: true
   nodePools:

--- a/tests/performance/suites/keyauth/test_data/cluster_values.yaml
+++ b/tests/performance/suites/keyauth/test_data/cluster_values.yaml
@@ -1,0 +1,15 @@
+global:
+  apps:
+    certManager:
+      values:
+        config:
+          apiVersion: controller.config.cert-manager.io/v1alpha1
+          enableGatewayAPI: true
+          kind: ControllerConfiguration
+  connectivity:
+    certManager:
+      useDnsChallenges: true
+  nodePools:
+    def00:
+      minSize: 5
+      maxSize: 5

--- a/tests/performance/suites/keyauth/test_data/test-scenario.js
+++ b/tests/performance/suites/keyauth/test_data/test-scenario.js
@@ -1,0 +1,198 @@
+import http from "k6/http";
+import { check, group } from "k6";
+
+// Key-auth load scenario. Ported from
+// cni-gateway-api-use-cases-k6/k6/use-cases/key-auth.js, but driven against the
+// microservices-demo (Online Boutique) backend instead of the echo service. An
+// API key is enforced at the gateway (Envoy Gateway SecurityPolicy apiKeyAuth /
+// Kong key-auth plugin), extracted from the x-api-key header, so every
+// iteration asserts the three canonical key-auth outcomes:
+//   - valid key   -> 200 (request reaches the boutique frontend)
+//   - wrong key   -> 401 (rejected at the gateway)
+//   - missing key -> 401 (rejected at the gateway)
+//
+// API key auth is not natively supported by ingress-nginx, so — matching the
+// upstream use case (providers: kong, envoy) — the reverse-proxy comparison is
+// Kong only. Load shape, SLO thresholds and the Envoy-vs-reverse-proxy
+// two-scenario layout mirror the "basic"/"basicauth" suites.
+
+// All tunables read from environment variables (set in the TestRun CRD)
+// with sensible defaults so the script still works standalone.
+
+// Infrastructure
+const ENDPOINTS  = parseInt(__ENV.ENDPOINTS || "10", 10);
+const BASE_DOMAIN = __ENV.BASE_DOMAIN;
+
+// API key — must match what the suite provisions on the gateways (API_KEY in
+// the TestRun env). WRONG_API_KEY is a deliberately invalid value.
+const API_KEY       = __ENV.API_KEY || "k6-perf-test-api-key-9f3a2b";
+const WRONG_API_KEY = "incorrect-api-key-value";
+
+// Scenario timing & load shape
+const SCENARIO_DURATION_SECONDS  = parseInt(__ENV.SCENARIO_DURATION_SECONDS  || "1200", 10); // 20m
+const WAIT_BETWEEN_SCENARIOS     = parseInt(__ENV.WAIT_BETWEEN_SCENARIOS     || "300",  10); // 5m
+const PEAK_HTTP_RPS              = parseInt(__ENV.PEAK_HTTP_RPS              || "50",   10); // target HTTP req/s
+const RAMP_STEP_HTTP_RPS         = parseInt(__ENV.RAMP_STEP_HTTP_RPS         || "0",    10); // 0 = no ramp
+const RAMP_STEP_DURATION_SECONDS = parseInt(__ENV.RAMP_STEP_DURATION_SECONDS || "300",  10);
+const PRE_ALLOCATED_VUS          = parseInt(__ENV.PRE_ALLOCATED_VUS          || "50",   10);
+const MAX_VUS                    = parseInt(__ENV.MAX_VUS                    || "150",  10);
+const GRACEFUL_STOP              = __ENV.GRACEFUL_STOP || "30s";
+
+// Each iteration of keyAuthFlow issues this many HTTP requests (valid, wrong,
+// missing). The *_HTTP_RPS budgets are HTTP req/s, so convert them into a k6
+// iteration (arrival) rate by dividing — mirrors the "basic" suite's
+// AVG_HTTP_PER_ITERATION handling so load levels stay comparable.
+const REQUESTS_PER_ITERATION = 3;
+const httpRpsToIterRate = (httpRps) =>
+  Math.max(1, Math.round(httpRps / REQUESTS_PER_ITERATION));
+const PEAK_ITERATION_RATE      = httpRpsToIterRate(PEAK_HTTP_RPS);
+const RAMP_STEP_ITERATION_RATE = RAMP_STEP_HTTP_RPS > 0 ? httpRpsToIterRate(RAMP_STEP_HTTP_RPS) : 0;
+
+// SLO thresholds — align with giantswarm/giantswarm#35147 recommendations.
+const SLO_P95_LATENCY_MS = __ENV.SLO_P95_LATENCY_MS || "500";
+const SLO_P99_LATENCY_MS = __ENV.SLO_P99_LATENCY_MS || "1000";
+const SLO_ERROR_RATE     = __ENV.SLO_ERROR_RATE      || "0.001";  // 0.1%
+const SLO_CHECKS_RATE    = __ENV.SLO_CHECKS_RATE     || "0.95";
+
+// Treat 401 as an expected status so the intentional "wrong"/"missing" key
+// requests do not inflate http_req_failed. Mirrors the upstream use-case's
+// `http.expectedStatuses({ min: 200, max: 399 }, 401)`.
+const expectedStatuses = http.expectedStatuses({ min: 200, max: 399 }, 401);
+
+function pickEnvoyBaseUrl() {
+  const n = Math.floor(Math.random() * ENDPOINTS);
+  return `https://onlineboutique.loadtesting-${n}.${BASE_DOMAIN}`;
+}
+
+function kongBaseUrl() {
+  // Kong runs as a Gateway API implementation here: the chart exposes a single
+  // HTTPRoute host (kong-onlineboutique.loadtesting.<base>), with no per-endpoint
+  // fan-out like the Envoy side, so all kong traffic targets that one host.
+  return `https://kong-onlineboutique.loadtesting.${BASE_DOMAIN}`;
+}
+
+function buildScenarioConfig() {
+  const base = {
+    timeUnit: "1s",
+    preAllocatedVUs: PRE_ALLOCATED_VUS,
+    maxVUs: MAX_VUS,
+    gracefulStop: GRACEFUL_STOP,
+  };
+  if (RAMP_STEP_ITERATION_RATE > 0 && PEAK_ITERATION_RATE > RAMP_STEP_ITERATION_RATE) {
+    const numSteps = Math.ceil(PEAK_ITERATION_RATE / RAMP_STEP_ITERATION_RATE);
+    const stages = [];
+    for (let i = 1; i <= numSteps; i++) {
+      const target = Math.min(i * RAMP_STEP_ITERATION_RATE, PEAK_ITERATION_RATE);
+      stages.push({ target, duration: `${RAMP_STEP_DURATION_SECONDS}s` });
+    }
+    const rampSeconds = numSteps * RAMP_STEP_DURATION_SECONDS;
+    const holdSeconds = Math.max(0, SCENARIO_DURATION_SECONDS - rampSeconds);
+    if (holdSeconds > 0) {
+      stages.push({ target: PEAK_ITERATION_RATE, duration: `${holdSeconds}s` });
+    }
+    return {
+      config: { ...base, executor: "ramping-arrival-rate", startRate: 0, stages },
+      totalSeconds: rampSeconds + holdSeconds,
+    };
+  }
+  return {
+    config: {
+      ...base,
+      executor: "constant-arrival-rate",
+      rate: PEAK_ITERATION_RATE,
+      duration: `${SCENARIO_DURATION_SECONDS}s`,
+    },
+    totalSeconds: SCENARIO_DURATION_SECONDS,
+  };
+}
+
+const { config: SCENARIO_CONFIG, totalSeconds: SCENARIO_TOTAL_SECONDS } = buildScenarioConfig();
+
+// Envoy starts immediately; Kong starts after Envoy's total runtime + the wait
+// window so we don't synchronize request bursts.
+const kongStartTime = `${SCENARIO_TOTAL_SECONDS + WAIT_BETWEEN_SCENARIOS}s`;
+
+export const options = {
+  scenarios: {
+    envoy_simulation: {
+      ...SCENARIO_CONFIG,
+      exec: "envoyScenario",
+      startTime: "0s",
+    },
+    kong_simulation: {
+      ...SCENARIO_CONFIG,
+      exec: "kongScenario",
+      startTime: kongStartTime,
+    },
+  },
+  thresholds: {
+    // Per-controller latency thresholds aligned with SLO targets from
+    // giantswarm/giantswarm#35147 (default: p95 < 500ms, p99 < 1000ms).
+    // Scoped to status:200 — the authenticated path that actually reaches the
+    // boutique — so the cheap gateway-side 401 reject path (which is tagged
+    // expected_response:true by expectedStatuses) doesn't skew the percentiles.
+    "http_req_duration{scenario:envoy_simulation,status:200}": [
+      `p(95)<${SLO_P95_LATENCY_MS}`,
+      `p(99)<${SLO_P99_LATENCY_MS}`,
+    ],
+    [`http_req_duration{scenario:kong_simulation,status:200}`]: [
+      `p(95)<${SLO_P95_LATENCY_MS}`,
+      `p(99)<${SLO_P99_LATENCY_MS}`,
+    ],
+    // Error rate: 401 responses are tagged expected (see expectedStatuses), so
+    // http_req_failed only counts genuinely unexpected statuses.
+    "http_req_failed{scenario:envoy_simulation}": [`rate<${SLO_ERROR_RATE}`],
+    [`http_req_failed{scenario:kong_simulation}`]: [`rate<${SLO_ERROR_RATE}`],
+    // Auth assertions: valid->200, wrong->401, missing->401 must all hold.
+    "checks{scenario:envoy_simulation}": [`rate>${SLO_CHECKS_RATE}`],
+    [`checks{scenario:kong_simulation}`]: [`rate>${SLO_CHECKS_RATE}`],
+  },
+};
+
+// --- Key-auth flow ---------------------------------------------------------
+// Hits the boutique homepage through the gateway with a valid, wrong and
+// missing x-api-key header. checkHttp2=true for Envoy (HTTP/2 end-to-end);
+// false for Kong (HTTP/1.1 to the upstream).
+
+function keyAuthFlow(baseUrl, checkHttp2) {
+  group("Valid api key", function () {
+    const res = http.get(`${baseUrl}/`, {
+      headers: { "x-api-key": API_KEY },
+      responseCallback: expectedStatuses,
+    });
+    check(res, {
+      "valid key -> status 200": (r) => r.status === 200,
+      "valid key -> boutique served": (r) => r.body && r.body.includes("Online Boutique"),
+      ...(checkHttp2 && { "valid key -> protocol is HTTP/2": (r) => r.proto === "HTTP/2.0" }),
+    });
+  });
+
+  group("Wrong api key", function () {
+    const res = http.get(`${baseUrl}/`, {
+      headers: { "x-api-key": WRONG_API_KEY },
+      responseCallback: expectedStatuses,
+    });
+    check(res, {
+      "wrong key -> status 401": (r) => r.status === 401,
+    });
+  });
+
+  group("Missing api key", function () {
+    const res = http.get(`${baseUrl}/`, {
+      responseCallback: expectedStatuses,
+    });
+    check(res, {
+      "missing key -> status 401": (r) => r.status === 401,
+    });
+  });
+}
+
+// --- Scenario entry points ---
+
+export function envoyScenario() {
+  keyAuthFlow(pickEnvoyBaseUrl(), true);
+}
+
+export function kongScenario() {
+  keyAuthFlow(kongBaseUrl(), false);
+}


### PR DESCRIPTION
This PR introduces a new performance test suite based on Adidas key-auth use case. it's an Envoy vs Kong only scenario as NGINX doesn't support key auth.

### Checklist

- [x] Update changelog in CHANGELOG.md.
