### PR TITLE
chore(tests): add mobilelatency performance test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `basicauth` performance test suite.
 - Add `keyauth` performance test suite.
+- Add `mobilelatency` performance test suite.
 
 ### Changed
 

--- a/tests/performance/suites/mobilelatency/bundle_values.yaml
+++ b/tests/performance/suites/mobilelatency/bundle_values.yaml
@@ -1,0 +1,33 @@
+apps:
+  gatewayApiConfig:
+    enabled: true
+    userConfig:
+      configMap:
+        values: |
+          gateways:
+            default:
+              backendTrafficPolicy:
+                circuitBreaker:
+                  maxConnections: 8192
+                  maxPendingRequests: 8192
+                  maxParallelRequests: 8192
+                  maxParallelRetries: 1024
+              envoyProxy:
+                enabled: true
+              allowedListeners:
+                enabled: true
+                namespaces:
+                  from: All
+              listeners:
+                http:
+                  httpsRedirectEnabled: true
+                  allowedRoutes:
+                    namespaces:
+                      from: All
+                https:
+                  subdomains:
+                    - onlineboutique
+                  certificate:
+                    issuer:
+                      kind: ClusterIssuer
+                      name: letsencrypt-giantswarm

--- a/tests/performance/suites/mobilelatency/cluster_values_test.go
+++ b/tests/performance/suites/mobilelatency/cluster_values_test.go
@@ -1,0 +1,69 @@
+package mobilelatency
+
+import (
+	"fmt"
+	"os"
+)
+
+// clusterValuesFile is the workload-cluster values file the apptest framework
+// reads verbatim at cluster standup (clusterbuilder.LoadOrBuildCluster reads
+// "./test_data/cluster_values.yaml" relative to the suite working directory). It
+// applies no templating, so we materialize the file at package init based on the
+// selected proxy controller.
+const clusterValuesFile = "test_data/cluster_values.yaml"
+
+// baseClusterValues is the default (nginx) workload-cluster configuration. It
+// must stay byte-identical to the checked-in test_data/cluster_values.yaml so a
+// default run rewrites it to the same content (no-op, no git churn).
+const baseClusterValues = `global:
+  apps:
+    certManager:
+      values:
+        config:
+          apiVersion: controller.config.cert-manager.io/v1alpha1
+          enableGatewayAPI: true
+          kind: ControllerConfiguration
+  connectivity:
+    certManager:
+      useDnsChallenges: true
+  nodePools:
+    def00:
+      minSize: 5
+      maxSize: 5
+`
+
+// kongClusterValues additionally points the cluster's wildcard DNS CNAME at the
+// gateway. Kong serves the boutique purely via Gateway API; without this the
+// DNS-01 ACME challenge for the kong wildcard certificate self-loops and fails.
+const kongClusterValues = `global:
+  apps:
+    certManager:
+      values:
+        config:
+          apiVersion: controller.config.cert-manager.io/v1alpha1
+          enableGatewayAPI: true
+          kind: ControllerConfiguration
+  connectivity:
+    dns:
+      wildcardCnameTarget: gateway
+    certManager:
+      useDnsChallenges: true
+  nodePools:
+    def00:
+      minSize: 5
+      maxSize: 5
+`
+
+// init materializes test_data/cluster_values.yaml before the apptest framework
+// reads it: the Kong variant adds global.connectivity.dns.wildcardCnameTarget,
+// while the default variant restores the base so a prior Kong run cannot leak
+// the override into a subsequent nginx run.
+func init() {
+	content := baseClusterValues
+	if proxyController == proxyControllerKong {
+		content = kongClusterValues
+	}
+	if err := os.WriteFile(clusterValuesFile, []byte(content), 0o600); err != nil {
+		panic(fmt.Sprintf("failed to materialize %s: %v", clusterValuesFile, err))
+	}
+}

--- a/tests/performance/suites/mobilelatency/config.env
+++ b/tests/performance/suites/mobilelatency/config.env
@@ -26,7 +26,7 @@ HPA_MAX_REPLICAS=20
 # so this suite deploys go-httpbin and routes the /delay path to it. The
 # Deployment raises go-httpbin's -max-duration to 60s (default 10s) so the 12s
 # "over_10s" band is served faithfully. The image must be pullable in-cluster.
-HTTPBIN_IMAGE=gsoci.azurecr.io/giantswarm/go-httpbin:2.18.3
+HTTPBIN_IMAGE=gsoci.azurecr.io/giantswarm/go-httpbin:2.23.1
 
 # k6 load testing
 K6_NAMESPACE=gs-k6-operator

--- a/tests/performance/suites/mobilelatency/config.env
+++ b/tests/performance/suites/mobilelatency/config.env
@@ -1,0 +1,49 @@
+# Shared infrastructure
+WC=envoyloadtesting
+MC=graveler
+BASE_DOMAIN=gaws2.gigantic.io
+AZ=eu-north-1a
+RELEASE=34.1.0
+MAX_NODES=10
+MIN_NODES=3
+INSTANCE_TYPE=m5.xlarge
+
+# Reverse proxy controller to compare against Envoy Gateway. One of: nginx, kong.
+# Only the chosen controller's App CR + Helm values are deployed, and the k6
+# scenario runs envoy_simulation + the matching <controller>_simulation.
+PROXY_CONTROLLER=nginx
+
+# Cluster contexts (kubectl context names)
+MC_CONTEXT=teleport.giantswarm.io-graveler                  # Management cluster — WC App CRs applied here
+K6_CONTEXT=teleport.giantswarm.io-alba-seu01                # k6 cluster — TestRun + scenario ConfigMap here
+
+# Microservices demo app configuration
+PUBLIC_ENDPOINTS=10
+HPA_MIN_REPLICAS=1
+HPA_MAX_REPLICAS=20
+
+# Delay backend (go-httpbin). The boutique can't synthesize per-request latency,
+# so this suite deploys go-httpbin and routes the /delay path to it. The
+# Deployment raises go-httpbin's -max-duration to 60s (default 10s) so the 12s
+# "over_10s" band is served faithfully. The image must be pullable in-cluster.
+HTTPBIN_IMAGE=gsoci.azurecr.io/giantswarm/go-httpbin:2.18.3
+
+# k6 load testing
+K6_NAMESPACE=gs-k6-operator
+K6_IMAGE=gsoci.azurecr.io/giantswarm/k6:1.6.0
+TEST_ID=envoy-load-testing
+ENDPOINTS=10
+# Per-simulation duration (envoy runs first, then the reverse proxy after a wait).
+# The upstream mobile-latency use case uses 50m; kept shorter here so envoy +
+# wait + proxy fit inside the TestRun timeout. Accepts a k6 duration string.
+RUN_DURATION=20m
+WAIT_BETWEEN_SCENARIOS=300
+# Divides every band's RPS so the ~4888 RPS production distribution scales down to
+# a test cluster. 1 = full fidelity (~4888 RPS); 10 ≈ 489 RPS.
+REDUCTION_RPS_FACTOR=10
+GRACEFUL_STOP=30s
+PROMETHEUS_RW_URL=http://mimir-gateway.mimir.svc.cluster.local/api/v1/push
+K6_PROMETHEUS_RW_HTTP_HEADERS=X-Scope-OrgID:giantswarm # Must be set to the <key>:<value> format. Multiple headers can be separated by commas, e.g. "Header1:Value1,Header2:Value2"
+PROMETHEUS_RW_PUSH_INTERVAL=5s
+SLO_ERROR_RATE=0.001
+SLO_CHECKS_RATE=0.99

--- a/tests/performance/suites/mobilelatency/config_env_test.go
+++ b/tests/performance/suites/mobilelatency/config_env_test.go
@@ -1,0 +1,79 @@
+package mobilelatency
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+var configEnvOnce sync.Once
+
+// infraConfigKeys are config.env entries that identify the manual
+// load-testing pipeline's specific, long-lived cluster (management cluster,
+// workload cluster name, base domain, kube contexts). The e2e suite
+// provisions its own ephemeral workload cluster and discovers these at
+// runtime, so importing them from config.env would point the suite at the
+// wrong installation — e.g. a base domain with no matching Route 53 hosted
+// zone, which leaves every Let's Encrypt certificate stuck on DNS-01.
+var infraConfigKeys = map[string]bool{
+	"WC":          true,
+	"MC":          true,
+	"BASE_DOMAIN": true,
+	"MC_CONTEXT":  true,
+	"K6_CONTEXT":  true,
+}
+
+// loadConfigEnv seeds the process environment from the suite-local
+// config.env on first call, so the e2e suite shares app-tuning defaults
+// (PUBLIC_ENDPOINTS, HPA_*, k6 knobs) with the manual load-testing
+// pipeline. Infrastructure-identity keys (see infraConfigKeys)
+// are deliberately skipped — those are specific to the manual pipeline's
+// cluster and must be discovered at runtime for the ephemeral e2e cluster.
+// Real env vars already set by the Tekton pipeline (or a local override)
+// always win — this only fills in what's missing.
+//
+// File format mirrors `set -a; source config.env; set +a`: KEY=value lines,
+// '#' line comments, and ' #' inline comments stripped from values. Quotes
+// are not interpreted (none of the keys in config.env use them).
+func loadConfigEnv() {
+	configEnvOnce.Do(func() {
+		_, thisFile, _, ok := runtime.Caller(0)
+		if !ok {
+			return
+		}
+		path := filepath.Join(filepath.Dir(thisFile), "config.env")
+		f, err := os.Open(path)
+		if err != nil {
+			return
+		}
+		defer f.Close()
+
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+			eq := strings.IndexByte(line, '=')
+			if eq <= 0 {
+				continue
+			}
+			key := strings.TrimSpace(line[:eq])
+			if infraConfigKeys[key] {
+				continue
+			}
+			value := line[eq+1:]
+			if i := strings.Index(value, " #"); i >= 0 {
+				value = value[:i]
+			}
+			value = strings.TrimSpace(value)
+			if _, set := os.LookupEnv(key); set {
+				continue
+			}
+			_ = os.Setenv(key, value)
+		}
+	})
+}

--- a/tests/performance/suites/mobilelatency/dependencies_test.go
+++ b/tests/performance/suites/mobilelatency/dependencies_test.go
@@ -1,0 +1,212 @@
+package mobilelatency
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	applicationv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
+	"github.com/giantswarm/apptest-framework/v5/pkg/state"
+	"github.com/giantswarm/clustertest/v5/pkg/application"
+	"github.com/giantswarm/clustertest/v5/pkg/logger"
+	"github.com/giantswarm/clustertest/v5/pkg/wait"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const awsLBControllerBundleValues = `
+managementCluster:
+  name: %s
+  namespace: org-giantswarm
+
+clusterName: %s
+clusterID: %s
+
+provider: aws
+
+global:
+  podSecurityStandards:
+    enforced: true
+
+enableServiceMutatorWebhook: false
+`
+
+const kongAppValues = `
+ingressController:
+  enabled: true
+  createIngressClass: false
+  watchNamespaces:
+    - loadtesting
+    - kong
+  rbac:
+    gatewayAPI:
+      enabled: true
+  ingressClass: none  # Prevents KIC from reconciling Ingress resources; Gateway API only
+proxy:
+  annotations:
+    giantswarm.io/external-dns: managed
+    external-dns.alpha.kubernetes.io/hostname: kong-ingress.%s
+`
+
+// kongExtraObjectsValues is applied as an extraConfig overlay AFTER kong-app is
+// deployed and its KongClusterPlugin CRD is registered. Inlining these into the
+// initial kongAppValues fails on first install because Helm renders
+// extraObjects before the chart's own CRDs are applied.
+const kongExtraObjectsValues = `
+extraObjects:
+  - apiVersion: configuration.konghq.com/v1
+    kind: KongClusterPlugin
+    metadata:
+      name: prometheus
+      annotations:
+        kubernetes.io/ingress.class: none
+      labels:
+        global: "true"
+    plugin: prometheus
+    config:
+      status_code_metrics: true
+      latency_metrics: true
+      bandwidth_metrics: true
+      upstream_health_metrics: true
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: kong-app-kong-app-ingressclass-reader
+    rules:
+      - apiGroups: ["networking.k8s.io"]
+        resources: ["ingressclasses"]
+        verbs: ["get", "list", "watch"]
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: kong-app-kong-app-ingressclass-reader
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: kong-app-kong-app-ingressclass-reader
+    subjects:
+      - kind: ServiceAccount
+        name: kong-app-kong-app
+        namespace: kong
+`
+
+const ingressNginxValues = `
+controller:
+  ingressClassResource:
+    enabled: true
+  service:
+    externalDNS:
+      enabled: true
+  extraArgs:
+    update-status: "true"
+`
+
+// gateway-api-bundle is installed by apptest-framework via
+// InAppBundle and not listed here.
+var dependencyVersions = map[string]string{
+	"aws-lb-controller-bundle": "5.2.0",
+	"ingress-nginx":            "4.3.3",
+	"kong-app":                 "5.2.2",
+	"microservices-demo-app":   "0.8.1",
+}
+
+func deployDependency(depName, depValues string, installNs ...string) *application.Application {
+	By(fmt.Sprintf("deploying %s", depName))
+
+	org := state.GetCluster().Organization
+
+	isBundle := strings.Contains(depName, "bundle")
+	installNamespace := org.GetNamespace()
+	if !isBundle {
+		installNamespace = "default"
+	}
+	if len(installNs) > 0 && installNs[0] != "" {
+		installNamespace = installNs[0]
+	}
+
+	version, ok := dependencyVersions[depName]
+	if !ok {
+		Fail(fmt.Sprintf("no version pin defined for dependency %q — add it to dependencyVersions", depName))
+	}
+
+	clusterName := state.GetCluster().Name
+	app := application.New(fmt.Sprintf("%s-%s", clusterName, depName), depName).
+		WithCatalog("giantswarm").
+		WithOrganization(*org).
+		WithVersion(version).
+		WithClusterName(clusterName).
+		WithInCluster(isBundle).
+		WithInstallNamespace(installNamespace).
+		MustWithValues(depValues, nil)
+
+	err := state.GetFramework().MC().DeployApp(state.GetContext(), *app)
+	Expect(err).NotTo(HaveOccurred())
+
+	return app
+}
+
+func waitForDependency(app *application.Application) {
+	By(fmt.Sprintf("waiting for %s to be deployed", app.InstallName))
+
+	org := state.GetCluster().Organization
+	Eventually(wait.IsAppDeployed(state.GetContext(), state.GetFramework().MC(), app.InstallName, org.GetNamespace())).
+		WithTimeout(10 * time.Minute).
+		WithPolling(5 * time.Second).
+		Should(BeTrue())
+}
+
+// addExtraConfigToApp creates a ConfigMap with the given values and adds it
+// to the App CR's spec.extraConfigs list. Idempotent — safe to call on retry.
+func addExtraConfigToApp(appName, configMapName, values string) {
+	ctx := state.GetContext()
+	mc := state.GetFramework().MC()
+	org := state.GetCluster().Organization
+	namespace := org.GetNamespace()
+
+	logger.Log("Ensuring extra config ConfigMap %s/%s for App %s", namespace, configMapName, appName)
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			"values": values,
+		},
+	}
+	err := mc.Create(ctx, cm)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		Expect(err).NotTo(HaveOccurred(), "failed to create extra config ConfigMap %s/%s", namespace, configMapName)
+	}
+
+	// Read the current App CR to preserve existing extraConfigs
+	appCR := &applicationv1alpha1.App{}
+	err = mc.Get(ctx, types.NamespacedName{Name: appName, Namespace: namespace}, appCR)
+	Expect(err).NotTo(HaveOccurred(), "failed to get App CR %s/%s", namespace, appName)
+
+	// Check if the extra config is already present
+	for _, ec := range appCR.Spec.ExtraConfigs {
+		if ec.Name == configMapName && ec.Namespace == namespace {
+			logger.Log("Extra config %s already present on App %s/%s", configMapName, namespace, appName)
+			return
+		}
+	}
+
+	appCR.Spec.ExtraConfigs = append(appCR.Spec.ExtraConfigs, applicationv1alpha1.AppExtraConfig{
+		Kind:      "configMap",
+		Name:      configMapName,
+		Namespace: namespace,
+		Priority:  25,
+	})
+
+	err = mc.Update(ctx, appCR)
+	Expect(err).NotTo(HaveOccurred(), "failed to update App CR %s/%s with extraConfigs", namespace, appName)
+
+	logger.Log("Added extra config %s to App %s/%s", configMapName, namespace, appName)
+}

--- a/tests/performance/suites/mobilelatency/helpers_test.go
+++ b/tests/performance/suites/mobilelatency/helpers_test.go
@@ -1,0 +1,296 @@
+package mobilelatency
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/giantswarm/apptest-framework/v5/pkg/state"
+	"github.com/giantswarm/clustertest/v5/pkg/application"
+	"github.com/giantswarm/clustertest/v5/pkg/logger"
+
+	cmv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func createWorkloadClusterNamespace(name string) {
+	wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
+	Expect(err).NotTo(HaveOccurred())
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	Eventually(func() error {
+		err := wcClient.Create(state.GetContext(), ns)
+		if err == nil || errors.IsAlreadyExists(err) {
+			return nil
+		}
+		logger.Log("Create namespace %s failed, will retry: %v", name, err)
+		return err
+	}).
+		WithTimeout(5 * time.Minute).
+		WithPolling(5 * time.Second).
+		Should(Succeed())
+}
+
+func getWorkloadClusterBaseDomain() string {
+	values := &application.ClusterValues{}
+	err := state.GetFramework().MC().GetHelmValues(state.GetCluster().Name, state.GetCluster().GetNamespace(), values)
+	Expect(err).NotTo(HaveOccurred())
+
+	if values.BaseDomain == "" {
+		Fail("baseDomain field missing from cluster helm values")
+	}
+
+	return fmt.Sprintf("%s.%s", state.GetCluster().Name, values.BaseDomain)
+}
+
+func newHttpClientWithProxy(endpoint string) *http.Client {
+	httpProxy := os.Getenv("HTTP_PROXY")
+	noProxy := os.Getenv("NO_PROXY")
+	useProxy := httpProxy != "" && !endpointMatchesNoProxy(endpoint, noProxy)
+
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			dialer := &net.Dialer{
+				Resolver: &net.Resolver{
+					PreferGo: true,
+					Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+						if useProxy {
+							u, err := url.Parse(httpProxy)
+							if err != nil {
+								logger.Log("Error parsing HTTP_PROXY as a URL %s", httpProxy)
+							} else {
+								if addr == u.Host {
+									// always use coredns for proxy address resolution.
+									var d net.Dialer
+									return d.Dial(network, address)
+								}
+							}
+						}
+						d := net.Dialer{
+							Timeout: time.Millisecond * time.Duration(10000),
+						}
+						return d.DialContext(ctx, "udp", "8.8.4.4:53")
+					},
+				},
+			}
+			return dialer.DialContext(ctx, network, addr)
+		},
+	}
+
+	if useProxy {
+		logger.Log("Detected need to use PROXY as HTTP_PROXY env var was set to %s", httpProxy)
+		transport.Proxy = http.ProxyFromEnvironment
+	} else if httpProxy != "" {
+		logger.Log("Skipping HTTP_PROXY %s for endpoint %s because it matches NO_PROXY=%s", httpProxy, endpoint, noProxy)
+	}
+
+	httpClient := &http.Client{
+		Transport: transport,
+	}
+	return httpClient
+}
+
+func endpointMatchesNoProxy(endpoint, noProxy string) bool {
+	if noProxy == "" {
+		return false
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return false
+	}
+	host := u.Hostname()
+	if host == "" {
+		return false
+	}
+	for entry := range strings.SplitSeq(noProxy, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		if entry == "*" {
+			return true
+		}
+		entry = strings.TrimPrefix(entry, ".")
+		if host == entry || strings.HasSuffix(host, "."+entry) {
+			return true
+		}
+	}
+	return false
+}
+
+func deploymentReadyInNamespace(namespace string) (bool, error) {
+	wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
+	if err != nil {
+		return false, err
+	}
+
+	logger.Log("Checking for ready deployments in namespace %s", namespace)
+	deployments := &appsv1.DeploymentList{}
+	err = wcClient.List(state.GetContext(), deployments, client.InNamespace(namespace))
+	if err != nil {
+		return false, err
+	}
+
+	for i := range deployments.Items {
+		dep := &deployments.Items[i]
+		if dep.Spec.Replicas == nil {
+			continue
+		}
+		desired := *dep.Spec.Replicas
+		if desired > 0 && dep.Status.ReadyReplicas == desired && dep.Status.AvailableReplicas == desired {
+			logger.Log("Deployment %s/%s is ready (%d/%d replicas)", namespace, dep.Name, dep.Status.ReadyReplicas, desired)
+			return true, nil
+		}
+	}
+
+	logger.Log("No ready deployment found in namespace %s", namespace)
+	return false, nil
+}
+
+func loadBalancerServiceReadyInNamespace(namespace string) (bool, error) {
+	wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
+	if err != nil {
+		return false, err
+	}
+
+	logger.Log("Checking for ready LoadBalancer services in namespace %s", namespace)
+	services := &corev1.ServiceList{}
+	err = wcClient.List(state.GetContext(), services, client.InNamespace(namespace))
+	if err != nil {
+		return false, err
+	}
+
+	for i := range services.Items {
+		svc := &services.Items[i]
+		if svc.Spec.Type == corev1.ServiceTypeLoadBalancer {
+			if len(svc.Status.LoadBalancer.Ingress) > 0 &&
+				(svc.Status.LoadBalancer.Ingress[0].Hostname != "" || svc.Status.LoadBalancer.Ingress[0].IP != "") {
+				logger.Log("LoadBalancer service %s/%s is ready with address: %s%s",
+					namespace, svc.Name, svc.Status.LoadBalancer.Ingress[0].Hostname, svc.Status.LoadBalancer.Ingress[0].IP)
+				return true, nil
+			}
+		}
+	}
+
+	logger.Log("No ready LoadBalancer service found in namespace %s", namespace)
+	return false, nil
+}
+
+func allCertificatesReady(expected []types.NamespacedName) (bool, error) {
+	wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
+	if err != nil {
+		return false, err
+	}
+
+	logger.Log("Listing all certificates on the workload cluster")
+	certs := &cmv1.CertificateList{}
+	if err := wcClient.List(state.GetContext(), certs); err != nil {
+		return false, err
+	}
+
+	present := make(map[types.NamespacedName]struct{}, len(certs.Items))
+	for i := range certs.Items {
+		cert := &certs.Items[i]
+		present[types.NamespacedName{Namespace: cert.Namespace, Name: cert.Name}] = struct{}{}
+	}
+	for _, key := range expected {
+		if _, ok := present[key]; !ok {
+			logger.Log("Expected certificate %s not found yet", key)
+			return false, nil
+		}
+	}
+
+	for i := range certs.Items {
+		cert := &certs.Items[i]
+		ready := false
+		for _, condition := range cert.Status.Conditions {
+			if condition.Type == cmv1.CertificateConditionReady && condition.Status == cmmeta.ConditionTrue {
+				ready = true
+				break
+			}
+		}
+		if !ready {
+			logger.Log("Certificate %s/%s not ready yet", cert.Namespace, cert.Name)
+			return false, nil
+		}
+	}
+
+	logger.Log("All %d certificates are ready", len(certs.Items))
+	return true, nil
+}
+
+func crdExists(name string) (bool, error) {
+	wcClient, err := state.GetFramework().WC(state.GetCluster().Name)
+	if err != nil {
+		return false, err
+	}
+
+	logger.Log("Checking if CRD %s exists", name)
+	crd := &unstructured.Unstructured{}
+	crd.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "apiextensions.k8s.io",
+		Version: "v1",
+		Kind:    "CustomResourceDefinition",
+	})
+	err = wcClient.Get(state.GetContext(), client.ObjectKey{Name: name}, crd)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Log("CRD %s not found yet", name)
+			return false, nil
+		}
+		return false, err
+	}
+
+	logger.Log("CRD %s exists", name)
+	return true, nil
+}
+
+func expectEndpointServesTraffic(endpoint string) {
+	httpClient := newHttpClientWithProxy(endpoint)
+	Eventually(func() (string, error) {
+		logger.Log("Trying to get a successful response from %s", endpoint)
+		resp, err := httpClient.Get(endpoint)
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			logger.Log("Was expecting status code '%d' but actually got '%d'", http.StatusOK, resp.StatusCode)
+			return "", err
+		}
+
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			logger.Log("Was not expecting the response body to be empty")
+			return "", err
+		}
+
+		return string(bodyBytes), nil
+	}).
+		WithTimeout(15 * time.Minute).
+		WithPolling(5 * time.Second).
+		Should(ContainSubstring("Online Boutique"))
+}

--- a/tests/performance/suites/mobilelatency/httpbin_test.go
+++ b/tests/performance/suites/mobilelatency/httpbin_test.go
@@ -58,7 +58,7 @@ func publicEndpoints() int {
 }
 
 func httpbinImage() string {
-	return envOrDefault("HTTPBIN_IMAGE", "gsoci.azurecr.io/giantswarm/go-httpbin:2.18.3")
+	return envOrDefault("HTTPBIN_IMAGE", "gsoci.azurecr.io/giantswarm/go-httpbin:2.23.1")
 }
 
 func boolPtr(b bool) *bool    { return &b }

--- a/tests/performance/suites/mobilelatency/httpbin_test.go
+++ b/tests/performance/suites/mobilelatency/httpbin_test.go
@@ -1,0 +1,354 @@
+package mobilelatency
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/giantswarm/apptest-framework/v5/pkg/state"
+	"github.com/giantswarm/clustertest/v5/pkg/logger"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	cr "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// httpbin is deployed into the boutique's namespace so HTTPRoutes/Ingresses
+	// can reference it without cross-namespace ReferenceGrants.
+	httpbinNamespace = "loadtesting"
+	httpbinName      = "httpbin"
+	httpbinPort      = 8080
+
+	// delayPath is overlaid (as a more specific PathPrefix) on the existing
+	// boutique hostnames, so go-httpbin's /delay/{seconds} is reachable without
+	// minting new DNS records or certificates.
+	delayPath = "/delay"
+
+	// The boutique creates, per endpoint i, a ListenerSet listeners-{i} in
+	// loadtesting-{i} (parented to the giantswarm-default Gateway in
+	// envoy-gateway-system) holding the *.loadtesting-{i} hostname. httpbin
+	// HTTPRoutes attach to these ListenerSets, exactly like the boutique's
+	// frontend-{i} routes, so per-namespace hostnames bind correctly.
+	envoyRouteNamespacePrefix = "loadtesting-"
+	envoyListenerSetPrefix    = "listeners-"
+)
+
+// publicEndpoints is the number of boutique endpoint namespaces / ListenerSets
+// the chart creates (httproute.namespaces.number). Must match the
+// PUBLIC_ENDPOINTS used in buildMicroservicesDemoAppValues.
+func publicEndpoints() int {
+	n, err := strconv.Atoi(envOrDefault("PUBLIC_ENDPOINTS", "10"))
+	if err != nil || n < 1 {
+		return 10
+	}
+	return n
+}
+
+func httpbinImage() string {
+	return envOrDefault("HTTPBIN_IMAGE", "gsoci.azurecr.io/giantswarm/go-httpbin:2.18.3")
+}
+
+func boolPtr(b bool) *bool    { return &b }
+func int32Ptr(i int32) *int32 { return &i }
+func int64Ptr(i int64) *int64 { return &i }
+
+func wcClient() cr.Client {
+	wc, err := state.GetFramework().WC(state.GetCluster().Name)
+	Expect(err).NotTo(HaveOccurred())
+	return wc
+}
+
+// createOrUpdate creates obj, or updates it in place (preserving resourceVersion)
+// if it already exists, so the step is safe to retry.
+func createOrUpdate(obj cr.Object) {
+	wc := wcClient()
+	ctx := state.GetContext()
+	err := wc.Create(ctx, obj)
+	if err == nil {
+		return
+	}
+	if !errors.IsAlreadyExists(err) {
+		Expect(err).NotTo(HaveOccurred(), "failed to create %T %s/%s", obj, obj.GetNamespace(), obj.GetName())
+	}
+	existing := obj.DeepCopyObject().(cr.Object)
+	err = wc.Get(ctx, cr.ObjectKey{Name: obj.GetName(), Namespace: obj.GetNamespace()}, existing)
+	Expect(err).NotTo(HaveOccurred())
+	obj.SetResourceVersion(existing.GetResourceVersion())
+	// A Service's clusterIP(s) are immutable; carry them over from the existing
+	// object so an update on retry isn't rejected for blanking them.
+	if svc, ok := obj.(*corev1.Service); ok {
+		cur := existing.(*corev1.Service)
+		svc.Spec.ClusterIP = cur.Spec.ClusterIP
+		svc.Spec.ClusterIPs = cur.Spec.ClusterIPs
+	}
+	err = wc.Update(ctx, obj)
+	Expect(err).NotTo(HaveOccurred(), "failed to update %T %s/%s", obj, obj.GetNamespace(), obj.GetName())
+}
+
+// applyHTTPRoute creates or updates a Gateway API HTTPRoute given as unstructured.
+func applyHTTPRoute(obj *unstructured.Unstructured) {
+	wc := wcClient()
+	ctx := state.GetContext()
+	existing := obj.DeepCopy()
+	err := wc.Get(ctx, cr.ObjectKey{Name: obj.GetName(), Namespace: obj.GetNamespace()}, existing)
+	if errors.IsNotFound(err) {
+		Expect(wc.Create(ctx, obj)).To(Succeed(), "failed to create HTTPRoute %s/%s", obj.GetNamespace(), obj.GetName())
+		return
+	}
+	Expect(err).NotTo(HaveOccurred())
+	obj.SetResourceVersion(existing.GetResourceVersion())
+	Expect(wc.Update(ctx, obj)).To(Succeed(), "failed to update HTTPRoute %s/%s", obj.GetNamespace(), obj.GetName())
+}
+
+// deployHttpbin deploys go-httpbin (Deployment + Service) into the loadtesting
+// namespace and waits for it to become ready. -max-duration is raised above the
+// 10s default so the 12s "over_10s" band is served faithfully.
+func deployHttpbin() {
+	labels := map[string]string{"app": httpbinName}
+
+	By("Creating the go-httpbin Deployment")
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: httpbinName, Namespace: httpbinNamespace, Labels: labels},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(3),
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: corev1.PodSpec{
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot:   boolPtr(true),
+						RunAsUser:      int64Ptr(1000),
+						RunAsGroup:     int64Ptr(1000),
+						FSGroup:        int64Ptr(1000),
+						SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+					},
+					Containers: []corev1.Container{{
+						Name:  httpbinName,
+						Image: httpbinImage(),
+						Args:  []string{fmt.Sprintf("-port=%d", httpbinPort), "-max-duration=60s"},
+						Ports: []corev1.ContainerPort{{ContainerPort: httpbinPort}},
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{
+								Path: "/status/200",
+								Port: intstr.FromInt(httpbinPort),
+							}},
+							InitialDelaySeconds: 5,
+							PeriodSeconds:       10,
+						},
+						SecurityContext: &corev1.SecurityContext{
+							RunAsNonRoot:             boolPtr(true),
+							RunAsUser:                int64Ptr(1000),
+							RunAsGroup:               int64Ptr(1000),
+							AllowPrivilegeEscalation: boolPtr(false),
+							ReadOnlyRootFilesystem:   boolPtr(true),
+							Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+							SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+						},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("100m"),
+								corev1.ResourceMemory: resource.MustParse("64Mi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("500m"),
+								corev1.ResourceMemory: resource.MustParse("128Mi"),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	createOrUpdate(dep)
+
+	By("Creating the go-httpbin Service")
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: httpbinName, Namespace: httpbinNamespace, Labels: labels},
+		Spec: corev1.ServiceSpec{
+			Selector: labels,
+			Ports: []corev1.ServicePort{{
+				Name:       "http",
+				Port:       httpbinPort,
+				TargetPort: intstr.FromInt(httpbinPort),
+				Protocol:   corev1.ProtocolTCP,
+			}},
+		},
+	}
+	createOrUpdate(svc)
+
+	By("Waiting for go-httpbin to be ready")
+	Eventually(httpbinReady).
+		WithTimeout(10 * time.Minute).
+		WithPolling(5 * time.Second).
+		Should(BeTrue())
+}
+
+func httpbinReady() (bool, error) {
+	dep := &appsv1.Deployment{}
+	err := wcClient().Get(state.GetContext(), cr.ObjectKey{Name: httpbinName, Namespace: httpbinNamespace}, dep)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	desired := int32(1)
+	if dep.Spec.Replicas != nil {
+		desired = *dep.Spec.Replicas
+	}
+	return dep.Status.ReadyReplicas >= desired, nil
+}
+
+// routeHttpbinThroughGateways overlays the /delay path of the existing boutique
+// hostnames onto go-httpbin: an HTTPRoute on the Envoy gateway always, and an
+// Ingress (nginx) or HTTPRoute (kong) for the selected reverse proxy. The more
+// specific /delay PathPrefix wins over the boutique frontend's "/" route, so the
+// boutique keeps serving everything else.
+func routeHttpbinThroughGateways() {
+	baseDomain := getWorkloadClusterBaseDomain()
+
+	By("Routing /delay to go-httpbin on every Envoy endpoint")
+	// One HTTPRoute per endpoint namespace, attached to that namespace's
+	// ListenerSet (listeners-{i}, itself parented to giantswarm-default), exactly
+	// like the boutique's frontend-{i} routes. The /delay prefix is overlaid on
+	// the existing onlineboutique.loadtesting-{i} hostname (reusing DNS + TLS).
+	// The backendRef to httpbin (in loadtesting) is permitted by the boutique's
+	// allow-from-frontend ReferenceGrant.
+	for i := 0; i < publicEndpoints(); i++ {
+		ns := fmt.Sprintf("%s%d", envoyRouteNamespacePrefix, i)
+		applyHTTPRoute(httpbinHTTPRoute(
+			fmt.Sprintf("httpbin-envoy-%d", i),
+			ns,
+			"ListenerSet", fmt.Sprintf("%s%d", envoyListenerSetPrefix, i), ns,
+			fmt.Sprintf("onlineboutique.loadtesting-%d.%s", i, baseDomain),
+		))
+	}
+
+	switch proxyController {
+	case proxyControllerNginx:
+		By("Routing /delay to go-httpbin on ingress-nginx")
+		createOrUpdate(httpbinNginxIngress(fmt.Sprintf("nginx-onlineboutique-0.loadtesting.%s", baseDomain)))
+	case proxyControllerKong:
+		By("Routing /delay to go-httpbin on the kong gateway")
+		applyHTTPRoute(httpbinHTTPRoute(
+			"httpbin-kong",
+			httpbinNamespace,
+			"Gateway", "kong", "loadtesting",
+			fmt.Sprintf("kong-onlineboutique.loadtesting.%s", baseDomain),
+		))
+	}
+}
+
+// httpbinHTTPRoute builds an HTTPRoute (in routeNamespace) attaching to the given
+// parent (a Gateway or ListenerSet) and forwarding the /delay prefix to the
+// httpbin Service.
+func httpbinHTTPRoute(name, routeNamespace, parentKind, parentName, parentNamespace, hostname string) *unstructured.Unstructured {
+	route := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "HTTPRoute",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": routeNamespace,
+		},
+		"spec": map[string]any{
+			"parentRefs": []any{
+				map[string]any{
+					"group":     "gateway.networking.k8s.io",
+					"kind":      parentKind,
+					"name":      parentName,
+					"namespace": parentNamespace,
+				},
+			},
+			"hostnames": []any{hostname},
+			"rules": []any{
+				map[string]any{
+					"matches": []any{
+						map[string]any{
+							"path": map[string]any{"type": "PathPrefix", "value": delayPath},
+						},
+					},
+					"backendRefs": []any{
+						map[string]any{
+							"group":     "",
+							"kind":      "Service",
+							"name":      httpbinName,
+							"namespace": httpbinNamespace,
+							"port":      int64(httpbinPort),
+						},
+					},
+				},
+			},
+		},
+	}}
+	route.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
+	return route
+}
+
+// httpbinNginxIngress builds an Ingress that forwards the /delay prefix of the
+// boutique nginx host to go-httpbin, reusing the wildcard TLS secret.
+func httpbinNginxIngress(host string) *networkingv1.Ingress {
+	pathType := networkingv1.PathTypePrefix
+	ingressClass := "nginx"
+	return &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Name: "httpbin-nginx", Namespace: httpbinNamespace},
+		Spec: networkingv1.IngressSpec{
+			IngressClassName: &ingressClass,
+			TLS: []networkingv1.IngressTLS{{
+				Hosts:      []string{host},
+				SecretName: "nginx-ingress-wildcard-tls",
+			}},
+			Rules: []networkingv1.IngressRule{{
+				Host: host,
+				IngressRuleValue: networkingv1.IngressRuleValue{
+					HTTP: &networkingv1.HTTPIngressRuleValue{
+						Paths: []networkingv1.HTTPIngressPath{{
+							Path:     delayPath,
+							PathType: &pathType,
+							Backend: networkingv1.IngressBackend{
+								Service: &networkingv1.IngressServiceBackend{
+									Name: httpbinName,
+									Port: networkingv1.ServiceBackendPort{Number: httpbinPort},
+								},
+							},
+						}},
+					},
+				},
+			}},
+		},
+	}
+}
+
+// expectDelayServesTraffic verifies go-httpbin is reachable through the gateway
+// at the /delay endpoint, polling to absorb route-propagation delay.
+func expectDelayServesTraffic(baseURL string) {
+	httpClient := newHttpClientWithProxy(baseURL)
+	url := fmt.Sprintf("%s/delay/0", baseURL)
+
+	By(fmt.Sprintf("expecting %s to return 200", url))
+	Eventually(func() (int, error) {
+		resp, err := httpClient.Get(url)
+		if err != nil {
+			return 0, err
+		}
+		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		logger.Log("GET %s -> %d", url, resp.StatusCode)
+		return resp.StatusCode, nil
+	}).
+		WithTimeout(15 * time.Minute).
+		WithPolling(10 * time.Second).
+		Should(Equal(http.StatusOK))
+}

--- a/tests/performance/suites/mobilelatency/k6_helpers_test.go
+++ b/tests/performance/suites/mobilelatency/k6_helpers_test.go
@@ -1,0 +1,376 @@
+package mobilelatency
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/giantswarm/apptest-framework/v5/pkg/state"
+	"github.com/giantswarm/clustertest/v5/pkg/client"
+	"github.com/giantswarm/clustertest/v5/pkg/logger"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	cr "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// testRunGone is the sentinel stage returned by getTestRunStage when the
+// TestRun CR no longer exists (typically because k6-operator cleaned it up
+// after completion with cleanup: post).
+const testRunGone = "gone"
+
+const defaultK6KubeconfigPath = "/etc/k6-kubeconfig"
+
+// prometheusCredentialsSecret is the secret that the k6 runner reads via
+// envFrom to authenticate against the Prometheus remote-write endpoint. It is
+// populated by mirrorPrometheusCredentials from kube-system/alloy-metrics on
+// the management cluster
+const prometheusCredentialsSecret = "k6-prometheus-rw-credentials"
+
+// prometheusOffEnvVar disables the Prometheus remote-write integration on the
+// e2e TestRun when set to a truthy value. Useful for local dev runs that don't
+// have permission to read kube-system/alloy-metrics on the MC.
+const prometheusOffEnvVar = "E2E_K6_PROMETHEUS_OFF"
+
+func prometheusEnabled() bool {
+	v := os.Getenv(prometheusOffEnvVar)
+	return v == "" || v == "0" || v == "false"
+}
+
+// k6Client is a cached Kubernetes client built from E2E_K6_KUBECONFIG. The
+// suite no longer applies the TestRun via this client — that now goes onto
+// the MC — but the helpers are kept for any out-of-tree caller that still
+// wants to talk to a separate k6 cluster.
+var k6Client *client.Client
+
+func getK6KubeconfigPath() string {
+	if p := os.Getenv("E2E_K6_KUBECONFIG"); p != "" {
+		return p
+	}
+	return defaultK6KubeconfigPath
+}
+
+// getK6Client returns a cached Kubernetes client for the k6 cluster.
+// It reads the kubeconfig from E2E_K6_KUBECONFIG (default: /etc/k6-kubeconfig).
+// Kept for reference / future use; the e2e suite itself talks to the MC.
+func getK6Client() *client.Client {
+	if k6Client != nil {
+		return k6Client
+	}
+
+	kubeconfigPath := getK6KubeconfigPath()
+	logger.Log("Creating k6 cluster client from kubeconfig at %s", kubeconfigPath)
+
+	var err error
+	k6Client, err = client.New(kubeconfigPath)
+	Expect(err).NotTo(HaveOccurred(), "failed to create k6 cluster client from %s", kubeconfigPath)
+
+	return k6Client
+}
+
+func getK6Namespace() string {
+	ns := os.Getenv("E2E_K6_NAMESPACE")
+	if ns == "" {
+		return "k6-operator"
+	}
+	return ns
+}
+
+func envOrDefault(key, fallback string) string {
+	loadConfigEnv()
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func buildScenarioConfigMap(name, namespace string) *corev1.ConfigMap {
+	_, thisFile, _, ok := runtime.Caller(0)
+	Expect(ok).To(BeTrue(), "failed to resolve test file path")
+
+	// Read the canonical scenario script from the suite-local
+	// test_data/test-scenario.js, relative to this Go file.
+	scenarioPath := filepath.Join(filepath.Dir(thisFile), "test_data", "test-scenario.js")
+	content, err := os.ReadFile(scenarioPath)
+	Expect(err).NotTo(HaveOccurred(), "failed to read test-scenario.js at %s", scenarioPath)
+
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			"test-scenario.js": string(content),
+		},
+	}
+}
+
+func securityContext() map[string]any {
+	return map[string]any{
+		"fsGroup":      int64(1000),
+		"runAsGroup":   int64(1000),
+		"runAsNonRoot": true,
+		"runAsUser":    int64(1000),
+		"seccompProfile": map[string]any{
+			"type": "RuntimeDefault",
+		},
+	}
+}
+
+func containerSecurityContext() map[string]any {
+	return map[string]any{
+		"runAsNonRoot":             true,
+		"runAsUser":                int64(1000),
+		"runAsGroup":               int64(1000),
+		"readOnlyRootFilesystem":   false,
+		"allowPrivilegeEscalation": false,
+		"capabilities": map[string]any{
+			"drop": []any{"ALL"},
+		},
+		"seccompProfile": map[string]any{
+			"type": "RuntimeDefault",
+		},
+	}
+}
+
+func buildTestRunUnstructured(name, namespace, configMapName, baseDomain, testID string) *unstructured.Unstructured {
+	image := envOrDefault("K6_IMAGE", "gsoci.azurecr.io/giantswarm/k6:1.6.0")
+
+	env := []any{
+		map[string]any{"name": "BASE_DOMAIN", "value": baseDomain},
+		// ENDPOINTS (the number of loadtesting-{i} hosts k6 fans across) is bound
+		// to publicEndpoints() so it can never diverge from the number of httpbin
+		// HTTPRoutes / boutique namespaces the suite actually provisions.
+		map[string]any{"name": "ENDPOINTS", "value": strconv.Itoa(publicEndpoints())},
+		map[string]any{"name": "PROXY_CONTROLLER", "value": proxyController},
+		map[string]any{"name": "RUN_DURATION", "value": envOrDefault("RUN_DURATION", "20m")},
+		map[string]any{"name": "WAIT_BETWEEN_SCENARIOS", "value": envOrDefault("WAIT_BETWEEN_SCENARIOS", "300")},
+		map[string]any{"name": "REDUCTION_RPS_FACTOR", "value": envOrDefault("REDUCTION_RPS_FACTOR", "10")},
+		map[string]any{"name": "GRACEFUL_STOP", "value": envOrDefault("GRACEFUL_STOP", "30s")},
+		map[string]any{"name": "SLO_ERROR_RATE", "value": envOrDefault("SLO_ERROR_RATE", "0.001")},
+		map[string]any{"name": "SLO_CHECKS_RATE", "value": envOrDefault("SLO_CHECKS_RATE", "0.99")},
+	}
+
+	runner := map[string]any{
+		"image":                    image,
+		"env":                      env,
+		"containerSecurityContext": containerSecurityContext(),
+		"securityContext":          securityContext(),
+	}
+
+	spec := map[string]any{
+		"parallelism": int64(4),
+		"quiet":       "false",
+		"separate":    false,
+		"script": map[string]any{
+			"configMap": map[string]any{
+				"name": configMapName,
+				"file": "test-scenario.js",
+			},
+		},
+		"initializer": map[string]any{
+			"image":                    image,
+			"containerSecurityContext": containerSecurityContext(),
+			"securityContext":          securityContext(),
+		},
+		"starter": map[string]any{
+			"containerSecurityContext": containerSecurityContext(),
+			"securityContext":          securityContext(),
+		},
+	}
+
+	if prometheusEnabled() {
+		// Push metrics to Mimir so e2e runs show up in Grafana under the testID
+		// series — matches envoy-loadtesting/k6/testrun.yaml.
+		spec["arguments"] = fmt.Sprintf("-o experimental-prometheus-rw --tag testid=%s", testID)
+		runner["envFrom"] = []any{
+			map[string]any{
+				"secretRef": map[string]any{
+					"name": prometheusCredentialsSecret,
+				},
+			},
+		}
+		env = append(env,
+			map[string]any{"name": "K6_PROMETHEUS_RW_SERVER_URL", "value": envOrDefault("PROMETHEUS_RW_URL", "http://mimir-gateway.mimir.svc.cluster.local/api/v1/push")},
+			map[string]any{"name": "K6_PROMETHEUS_RW_HTTP_HEADERS", "value": envOrDefault("K6_PROMETHEUS_RW_HTTP_HEADERS", "X-Scope-OrgID:giantswarm")},
+			map[string]any{"name": "K6_PROMETHEUS_RW_PUSH_INTERVAL", "value": envOrDefault("PROMETHEUS_RW_PUSH_INTERVAL", "5s")},
+		)
+		runner["env"] = env
+	}
+
+	spec["runner"] = runner
+
+	testRun := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "k6.io/v1alpha1",
+			"kind":       "TestRun",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": spec,
+		},
+	}
+
+	testRun.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "k6.io",
+		Version: "v1alpha1",
+		Kind:    "TestRun",
+	})
+
+	return testRun
+}
+
+// mirrorPrometheusCredentials reads the alloy-metrics credentials from the
+// management cluster's kube-system namespace and writes them into the k6
+// namespace (also on the MC) under prometheusCredentialsSecret. The runner
+// reads them via envFrom to talk to the Prometheus remote-write endpoint.
+// Mirrors envoy-loadtesting/deploy.sh.
+func mirrorPrometheusCredentials(namespace string) {
+	ctx := state.GetContext()
+	mc := state.GetFramework().MC()
+
+	src := &corev1.Secret{}
+	err := mc.Get(ctx, cr.ObjectKey{Name: "alloy-metrics", Namespace: "kube-system"}, src)
+	Expect(err).NotTo(HaveOccurred(), "failed to read kube-system/alloy-metrics on the MC - set %s=true to skip Prometheus push", prometheusOffEnvVar)
+
+	username, ok := src.Data["metrics-username"]
+	Expect(ok).To(BeTrue(), "kube-system/alloy-metrics is missing the metrics-username key")
+	password, ok := src.Data["metrics-password"]
+	Expect(ok).To(BeTrue(), "kube-system/alloy-metrics is missing the metrics-password key")
+
+	dst := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      prometheusCredentialsSecret,
+			Namespace: namespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"K6_PROMETHEUS_RW_USERNAME": username,
+			"K6_PROMETHEUS_RW_PASSWORD": password,
+		},
+	}
+
+	// Best-effort delete-then-create so a partial / stale secret from a
+	// previous run doesn't trip up the runner.
+	_ = mc.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: prometheusCredentialsSecret, Namespace: namespace}})
+	err = mc.Create(ctx, dst)
+	Expect(err).NotTo(HaveOccurred(), "failed to create %s/%s on the MC", namespace, prometheusCredentialsSecret)
+
+	logger.Log("Mirrored alloy-metrics credentials into %s/%s", namespace, prometheusCredentialsSecret)
+}
+
+func getTestRunStage(name, namespace string) (string, error) {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "k6.io",
+		Version: "v1alpha1",
+		Kind:    "TestRun",
+	})
+
+	err := state.GetFramework().MC().Get(state.GetContext(), cr.ObjectKey{Name: name, Namespace: namespace}, obj)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Log("TestRun %s/%s no longer exists (cleaned up by operator)", namespace, name)
+			return testRunGone, nil
+		}
+		return "", err
+	}
+
+	stage, found, err := unstructured.NestedString(obj.Object, "status", "stage")
+	if err != nil || !found {
+		logger.Log("TestRun %s/%s stage not yet populated", namespace, name)
+		return "", nil
+	}
+
+	logger.Log("TestRun %s/%s stage: %s", namespace, name, stage)
+	return stage, nil
+}
+
+// assertTestRunSuccess verifies the TestRun finished successfully. If the
+// TestRun CR has been deleted (operator cleanup after completion), it falls
+// back to fallbackStage — the last stage observed during polling — so we can
+// still distinguish a clean finish from a deletion after an error.
+func assertTestRunSuccess(name, namespace, fallbackStage string) {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "k6.io",
+		Version: "v1alpha1",
+		Kind:    "TestRun",
+	})
+
+	err := state.GetFramework().MC().Get(state.GetContext(), cr.ObjectKey{Name: name, Namespace: namespace}, obj)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Log("TestRun %s/%s was cleaned up; asserting on last observed stage: %q", namespace, name, fallbackStage)
+			Expect(fallbackStage).To(Equal("finished"), "TestRun did not finish successfully before cleanup, last observed stage: %q", fallbackStage)
+			return
+		}
+		Expect(err).NotTo(HaveOccurred(), "failed to get TestRun for assertion")
+	}
+
+	stage, _, _ := unstructured.NestedString(obj.Object, "status", "stage")
+	Expect(stage).To(Equal("finished"), "TestRun did not finish successfully, stage: %s", stage)
+
+	// Log conditions for diagnostics
+	conditions, found, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if found {
+		for _, c := range conditions {
+			if cond, ok := c.(map[string]any); ok {
+				logger.Log("TestRun condition: type=%v status=%v reason=%v message=%v",
+					cond["type"], cond["status"], cond["reason"], cond["message"])
+			}
+		}
+	}
+}
+
+func cleanupK6Resources(testRunName, configMapName, namespace string) {
+	ctx := state.GetContext()
+	mc := state.GetFramework().MC()
+
+	// Delete TestRun
+	testRun := &unstructured.Unstructured{}
+	testRun.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "k6.io",
+		Version: "v1alpha1",
+		Kind:    "TestRun",
+	})
+	testRun.SetName(testRunName)
+	testRun.SetNamespace(namespace)
+	if err := mc.Delete(ctx, testRun); err != nil {
+		logger.Log("Cleanup: failed to delete TestRun %s/%s (may not exist): %v", namespace, testRunName, err)
+	}
+
+	// Delete ConfigMap
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: namespace,
+		},
+	}
+	if err := mc.Delete(ctx, cm); err != nil {
+		logger.Log("Cleanup: failed to delete ConfigMap %s/%s (may not exist): %v", namespace, configMapName, err)
+	}
+
+	// Delete Prometheus credentials secret so the next run mirrors fresh creds
+	credSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      prometheusCredentialsSecret,
+			Namespace: namespace,
+		},
+	}
+	if err := mc.Delete(ctx, credSecret); err != nil {
+		logger.Log("Cleanup: failed to delete Secret %s/%s (may not exist): %v", namespace, prometheusCredentialsSecret, err)
+	}
+
+	// Give the operator a moment to process the deletion
+	time.Sleep(5 * time.Second)
+}

--- a/tests/performance/suites/mobilelatency/performance_suite_test.go
+++ b/tests/performance/suites/mobilelatency/performance_suite_test.go
@@ -1,0 +1,570 @@
+package mobilelatency
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/giantswarm/apptest-framework/v5/pkg/state"
+	"github.com/giantswarm/apptest-framework/v5/pkg/suite"
+	"github.com/giantswarm/clustertest/v5/pkg/application"
+	"github.com/giantswarm/clustertest/v5/pkg/logger"
+	"github.com/giantswarm/clustertest/v5/pkg/wait"
+)
+
+const (
+	isUpgrade = false
+
+	proxyControllerNginx = "nginx"
+	proxyControllerKong  = "kong"
+
+	// proxyControllerEnvVar selects which ingress controller is deployed
+	// alongside Envoy Gateway.
+	proxyControllerEnvVar = "PROXY_CONTROLLER"
+)
+
+// proxyController is the ingress controller that this suite will install,
+// resolved once at package init from the PROXY_CONTROLLER env var.
+// Default: nginx.
+var proxyController = resolveProxyController()
+
+func resolveProxyController() string {
+	loadConfigEnv()
+	v := strings.ToLower(strings.TrimSpace(os.Getenv(proxyControllerEnvVar)))
+	switch v {
+	case "":
+		return proxyControllerNginx
+	case proxyControllerNginx, proxyControllerKong:
+		return v
+	default:
+		panic(fmt.Sprintf("%s must be %q or %q (got: %q)", proxyControllerEnvVar, proxyControllerNginx, proxyControllerKong, v))
+	}
+}
+
+// microservicesDemoAppValuesTmpl mirrors
+// envoy-loadtesting/wc-deployment/values/microservices-demo.yaml. ${BASE}
+// stands in for the source file's ${WC}.${BASE_DOMAIN} (the test framework
+// already hands us the concatenated FQDN as baseDomain).
+const microservicesDemoAppValuesTmpl = `
+images:
+  tag: v0.10.5
+
+ingress:
+  enabled: ${INGRESS_NGINX_ENABLED}
+  number: ${PUBLIC_ENDPOINTS}
+  base: ${BASE}
+  host: nginx-onlineboutique
+
+kong:
+  enabled: ${KONG_ENABLED}
+  number: ${PUBLIC_ENDPOINTS}
+  base: ${BASE}
+  host: kong-onlineboutique
+  ingressCname: kong-ingress.${BASE}
+
+httproute:
+  enabled: true
+  base: ${BASE}
+  hostname: onlineboutique
+  namespaces:
+    create: true
+    number: ${PUBLIC_ENDPOINTS}
+
+adService:
+  resources:
+    requests:
+      cpu: 200m
+      memory: 180Mi
+    limits:
+      cpu: 300m
+      memory: 300Mi
+  hpa:
+    enabled: true
+    minReplicas: ${HPA_MIN_REPLICAS}
+    maxReplicas: ${HPA_MAX_REPLICAS}
+    targetCPUUtilizationPercentage: 80
+
+cartService:
+  resources:
+    requests:
+      cpu: 200m
+      memory: 128Mi
+    limits:
+      cpu: 300m
+      memory: 256Mi
+  hpa:
+    enabled: true
+    minReplicas: ${HPA_MIN_REPLICAS}
+    maxReplicas: ${HPA_MAX_REPLICAS}
+    targetCPUUtilizationPercentage: 80
+
+checkoutService:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+  hpa:
+    enabled: true
+    minReplicas: ${HPA_MIN_REPLICAS}
+    maxReplicas: ${HPA_MAX_REPLICAS}
+    targetCPUUtilizationPercentage: 80
+
+currencyService:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+  hpa:
+    enabled: true
+    minReplicas: ${HPA_MIN_REPLICAS}
+    maxReplicas: ${HPA_MAX_REPLICAS}
+    targetCPUUtilizationPercentage: 80
+
+emailService:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+  hpa:
+    enabled: true
+    minReplicas: ${HPA_MIN_REPLICAS}
+    maxReplicas: ${HPA_MAX_REPLICAS}
+    targetCPUUtilizationPercentage: 80
+
+frontend:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+  hpa:
+    enabled: true
+    minReplicas: ${HPA_MIN_REPLICAS}
+    maxReplicas: ${HPA_MAX_REPLICAS}
+    targetCPUUtilizationPercentage: 80
+
+loadGenerator:
+  resources:
+    requests:
+      cpu: 300m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+paymentService:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+  hpa:
+    enabled: true
+    minReplicas: ${HPA_MIN_REPLICAS}
+    maxReplicas: ${HPA_MAX_REPLICAS}
+    targetCPUUtilizationPercentage: 80
+
+productCatalogService:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+  hpa:
+    enabled: true
+    minReplicas: ${HPA_MIN_REPLICAS}
+    maxReplicas: ${HPA_MAX_REPLICAS}
+    targetCPUUtilizationPercentage: 80
+
+recommendationService:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 220Mi
+    limits:
+      cpu: 200m
+      memory: 450Mi
+  hpa:
+    enabled: true
+    minReplicas: ${HPA_MIN_REPLICAS}
+    maxReplicas: ${HPA_MAX_REPLICAS}
+    targetCPUUtilizationPercentage: 80
+
+shippingService:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+  hpa:
+    enabled: true
+    minReplicas: ${HPA_MIN_REPLICAS}
+    maxReplicas: ${HPA_MAX_REPLICAS}
+    targetCPUUtilizationPercentage: 80
+`
+
+// buildMicroservicesDemoAppValues returns the values overlay applied to the
+// microservices-demo-app dependency. Mirrors
+// envoy-loadtesting/wc-deployment/values/microservices-demo.yaml; the
+// PUBLIC_ENDPOINTS / HPA_MIN_REPLICAS / HPA_MAX_REPLICAS knobs are read via
+// envOrDefault so config.env (loaded by loadConfigEnv) supplies the same
+// defaults as the manual pipeline. Only the chosen ingress controller branch
+// is enabled.
+func buildMicroservicesDemoAppValues(baseDomain string) string {
+	ingressEnabled := "false"
+	kongEnabled := "false"
+	switch proxyController {
+	case proxyControllerNginx:
+		ingressEnabled = "true"
+	case proxyControllerKong:
+		kongEnabled = "true"
+	}
+	vars := map[string]string{
+		"INGRESS_NGINX_ENABLED": ingressEnabled,
+		"KONG_ENABLED":          kongEnabled,
+		"BASE":                  baseDomain,
+		"PUBLIC_ENDPOINTS":      envOrDefault("PUBLIC_ENDPOINTS", "10"),
+		"HPA_MIN_REPLICAS":      envOrDefault("HPA_MIN_REPLICAS", "1"),
+		"HPA_MAX_REPLICAS":      envOrDefault("HPA_MAX_REPLICAS", "20"),
+	}
+	return os.Expand(microservicesDemoAppValuesTmpl, func(key string) string {
+		return vars[key]
+	})
+}
+
+func TestPerformance(t *testing.T) {
+	suite.New().
+		// envoy-gateway is the SUT; the framework installs it via the
+		// gateway-api-bundle so the gateway-api CRDs and the default
+		// Gateway/HTTPRoute config come up at the same time. Bundle-level
+		// values (ListenerSet, listeners, TLS issuer) live in
+		// bundle_values.yaml.
+		InAppBundle("gateway-api-bundle").
+		WithInstallNamespace("envoy-gateway-system").
+		WithIsUpgrade(isUpgrade).
+		WithValuesFile("./values.yaml").
+		WithBundleValuesFile("./bundle_values.yaml").
+		AfterClusterReady(func() {
+			var (
+				awsLBApp        *application.Application
+				ingressNginxApp *application.Application
+				kongApp         *application.Application
+			)
+
+			It("should create the loadtesting namespace", FlakeAttempts(3), func() {
+				createWorkloadClusterNamespace("loadtesting")
+			})
+
+			It("should install aws-load-balancer-controller", FlakeAttempts(3), func() {
+				mcName := state.GetFramework().MC().GetClusterName()
+				clusterName := state.GetCluster().Name
+				awsLBApp = deployDependency("aws-lb-controller-bundle", fmt.Sprintf(awsLBControllerBundleValues, mcName, clusterName, clusterName))
+			})
+
+			if proxyController == proxyControllerNginx {
+				It("should install ingress-nginx", FlakeAttempts(3), func() {
+					ingressNginxApp = deployDependency("ingress-nginx", ingressNginxValues)
+				})
+			}
+
+			It("should wait for aws-load-balancer-controller to be ready", FlakeAttempts(3), func() {
+				waitForDependency(awsLBApp)
+			})
+
+			if proxyController == proxyControllerNginx {
+				It("should wait for ingress-nginx to be ready", FlakeAttempts(3), func() {
+					waitForDependency(ingressNginxApp)
+				})
+			}
+
+			if proxyController == proxyControllerKong {
+				It("should install kong-app", FlakeAttempts(3), func() {
+					baseDomain := getWorkloadClusterBaseDomain()
+					kongApp = deployDependency("kong-app", fmt.Sprintf(kongAppValues, baseDomain), "kong")
+					waitForDependency(kongApp)
+				})
+
+				It("should configure kong prometheus plugin", FlakeAttempts(3), func() {
+					By("Waiting for KongClusterPlugin CRD to be registered")
+					Eventually(func() (bool, error) {
+						return crdExists("kongclusterplugins.configuration.konghq.com")
+					}).
+						WithTimeout(5 * time.Minute).
+						WithPolling(10 * time.Second).
+						Should(BeTrue())
+
+					By("Adding extraObjects config to kong-app via spec.extraConfigs")
+					clusterName := state.GetCluster().Name
+					addExtraConfigToApp(
+						fmt.Sprintf("%s-kong-app", clusterName),
+						fmt.Sprintf("%s-kong-extra-objects", clusterName),
+						kongExtraObjectsValues,
+					)
+				})
+			}
+		}).
+		Tests(func() {
+			var (
+				microservicesDemoApp *application.Application
+				nginxUrl             string
+				envoyUrl             string
+				kongUrl              string
+			)
+			BeforeEach(func() {
+				nginxUrl = fmt.Sprintf("https://nginx-onlineboutique-0.loadtesting.%s", getWorkloadClusterBaseDomain())
+				envoyUrl = fmt.Sprintf("https://onlineboutique.loadtesting-0.%s", getWorkloadClusterBaseDomain())
+				// Kong runs as a Gateway API implementation: the chart exposes a
+				// single HTTPRoute host (no per-endpoint fan-out like Envoy/nginx).
+				kongUrl = fmt.Sprintf("https://kong-onlineboutique.loadtesting.%s", getWorkloadClusterBaseDomain())
+			})
+
+			It("should have deployed envoy-gateway via the gateway-api-bundle", func() {
+				bundleApp := state.GetBundleApplication()
+				Expect(bundleApp).NotTo(BeNil())
+
+				Eventually(wait.IsAppDeployed(state.GetContext(), state.GetFramework().MC(), bundleApp.InstallName, bundleApp.GetNamespace())).
+					WithTimeout(15 * time.Minute).
+					WithPolling(5 * time.Second).
+					Should(BeTrue())
+
+				Eventually(func() (bool, error) {
+					done, err := wait.IsAppDeployed(state.GetContext(), state.GetFramework().MC(), state.GetApplication().InstallName, state.GetApplication().Organization.GetNamespace())()
+					if err != nil {
+						if errors.IsNotFound(err) {
+							logger.Log("App '%s/%s' doesn't exist yet", state.GetApplication().Organization.GetNamespace(), state.GetApplication().InstallName)
+							return false, nil
+						}
+						return false, err
+					}
+					return done, nil
+				}).
+					WithTimeout(15 * time.Minute).
+					WithPolling(5 * time.Second).
+					Should(BeTrue())
+			})
+
+			It("should have gateway api CRDs registered", func() {
+				for _, crd := range []string{
+					"gateways.gateway.networking.k8s.io",
+					"httproutes.gateway.networking.k8s.io",
+					"listenersets.gateway.networking.k8s.io",
+				} {
+					Eventually(func() (bool, error) {
+						return crdExists(crd)
+					}).
+						WithTimeout(5 * time.Minute).
+						WithPolling(10 * time.Second).
+						Should(BeTrue())
+				}
+			})
+
+			It("should have ready dependency deployments on the workload cluster", func() {
+				namespaces := []string{"aws-load-balancer-controller", "envoy-gateway-system"}
+				if proxyController == proxyControllerKong {
+					namespaces = append(namespaces, "kong")
+				}
+				for _, ns := range namespaces {
+					Eventually(func() (bool, error) {
+						return deploymentReadyInNamespace(ns)
+					}).
+						WithTimeout(10 * time.Minute).
+						WithPolling(5 * time.Second).
+						Should(BeTrue())
+				}
+			})
+
+			It("should install and wait for microservices-demo-app", func() {
+				baseDomain := getWorkloadClusterBaseDomain()
+				microservicesDemoApp = deployDependency("microservices-demo-app", buildMicroservicesDemoAppValues(baseDomain), "loadtesting")
+				waitForDependency(microservicesDemoApp)
+			})
+
+			It("should have ready LoadBalancer services on the workload cluster", func() {
+				namespaces := []string{"envoy-gateway-system"}
+				switch proxyController {
+				case proxyControllerNginx:
+					namespaces = append(namespaces, "default")
+				case proxyControllerKong:
+					namespaces = append(namespaces, "kong")
+				}
+				for _, ns := range namespaces {
+					Eventually(func() (bool, error) {
+						return loadBalancerServiceReadyInNamespace(ns)
+					}).
+						WithTimeout(10 * time.Minute).
+						WithPolling(10 * time.Second).
+						Should(BeTrue())
+				}
+			})
+
+			It("should have ready certificates on the workload cluster", func() {
+				expected := []types.NamespacedName{
+					{Namespace: "loadtesting-0", Name: "gateway-0-https"},
+				}
+				switch proxyController {
+				case proxyControllerNginx:
+					expected = append(expected, types.NamespacedName{Namespace: "loadtesting", Name: "frontend-nginx-wildcard"})
+				case proxyControllerKong:
+					expected = append(expected, types.NamespacedName{Namespace: "loadtesting", Name: "frontend-kong-wildcard"})
+				}
+
+				Eventually(func() (bool, error) {
+					return allCertificatesReady(expected)
+				}).
+					WithTimeout(20 * time.Minute).
+					WithPolling(5 * time.Second).
+					Should(BeTrue())
+			})
+			if proxyController == proxyControllerNginx {
+				It("should serve traffic from ingress-nginx", func() {
+					DeferCleanup(func() {
+						if CurrentSpecReport().Failed() {
+							AbortSuite("ingress-nginx failed to serve traffic, aborting remaining tests")
+						}
+					})
+					expectEndpointServesTraffic(nginxUrl)
+				})
+			}
+			It("should serve traffic from envoy gateway", func() {
+				DeferCleanup(func() {
+					if CurrentSpecReport().Failed() {
+						AbortSuite("envoy gateway failed to serve traffic, aborting remaining tests")
+					}
+				})
+				expectEndpointServesTraffic(envoyUrl)
+			})
+			if proxyController == proxyControllerKong {
+				It("should serve traffic from kong", func() {
+					DeferCleanup(func() {
+						if CurrentSpecReport().Failed() {
+							AbortSuite("kong failed to serve traffic, aborting remaining tests")
+						}
+					})
+					expectEndpointServesTraffic(kongUrl)
+				})
+			}
+			// The boutique frontend can't synthesize per-request latency, so the
+			// mobile-latency bands are served by go-httpbin's /delay endpoint,
+			// overlaid on the /delay path of the existing boutique hostnames
+			// (reusing their DNS + TLS). Deploy it, route it, and verify it
+			// before load testing.
+			It("should deploy go-httpbin", FlakeAttempts(3), func() {
+				deployHttpbin()
+			})
+			It("should route /delay to go-httpbin", FlakeAttempts(3), func() {
+				routeHttpbinThroughGateways()
+			})
+			It("should serve /delay from go-httpbin via envoy gateway on every endpoint", func() {
+				DeferCleanup(func() {
+					if CurrentSpecReport().Failed() {
+						AbortSuite("go-httpbin not reachable via envoy gateway, aborting remaining tests")
+					}
+				})
+				// k6 fans across all loadtesting-{i} endpoints, so verify each
+				// one's /delay route — not just loadtesting-0 — before load testing.
+				baseDomain := getWorkloadClusterBaseDomain()
+				for i := 0; i < publicEndpoints(); i++ {
+					expectDelayServesTraffic(fmt.Sprintf("https://onlineboutique.loadtesting-%d.%s", i, baseDomain))
+				}
+			})
+			if proxyController == proxyControllerNginx {
+				It("should serve /delay from go-httpbin via ingress-nginx", func() {
+					DeferCleanup(func() {
+						if CurrentSpecReport().Failed() {
+							AbortSuite("go-httpbin not reachable via ingress-nginx, aborting remaining tests")
+						}
+					})
+					expectDelayServesTraffic(nginxUrl)
+				})
+			}
+			if proxyController == proxyControllerKong {
+				It("should serve /delay from go-httpbin via kong", func() {
+					DeferCleanup(func() {
+						if CurrentSpecReport().Failed() {
+							AbortSuite("go-httpbin not reachable via kong, aborting remaining tests")
+						}
+					})
+					expectDelayServesTraffic(kongUrl)
+				})
+			}
+			It("should run k6 load tests successfully", func() {
+				k6Namespace := getK6Namespace()
+				baseDomain := getWorkloadClusterBaseDomain()
+				testRunName := fmt.Sprintf("e2e-load-test-%s", state.GetCluster().Name)
+				configMapName := fmt.Sprintf("e2e-load-test-scenario-%s", state.GetCluster().Name)
+				testID := envOrDefault("K6_TEST_ID", testRunName)
+
+				// Clean up any stale resources from a previous interrupted run
+				cleanupK6Resources(testRunName, configMapName, k6Namespace)
+
+				if prometheusEnabled() {
+					By("Mirroring alloy-metrics credentials into the k6 namespace")
+					mirrorPrometheusCredentials(k6Namespace)
+				}
+
+				By("Creating test scenario ConfigMap on the MC")
+				cm := buildScenarioConfigMap(configMapName, k6Namespace)
+				err := state.GetFramework().MC().Create(state.GetContext(), cm)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Creating TestRun on the MC")
+				testRun := buildTestRunUnstructured(testRunName, k6Namespace, configMapName, baseDomain, testID)
+				err = state.GetFramework().MC().Create(state.GetContext(), testRun)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Waiting for TestRun to complete")
+				var lastStage string
+				Eventually(func() (string, error) {
+					stage, err := getTestRunStage(testRunName, k6Namespace)
+					if err != nil {
+						return "", err
+					}
+					if stage != "" && stage != testRunGone {
+						lastStage = stage
+					}
+					return stage, nil
+				}).
+					WithTimeout(120 * time.Minute).
+					WithPolling(30 * time.Second).
+					Should(BeElementOf("finished", "error", testRunGone))
+
+				By("Asserting TestRun succeeded")
+				assertTestRunSuccess(testRunName, k6Namespace, lastStage)
+
+				By("Cleaning up k6 resources")
+				cleanupK6Resources(testRunName, configMapName, k6Namespace)
+			})
+		}).
+		AfterSuite(func() {
+			k6Namespace := getK6Namespace()
+			testRunName := fmt.Sprintf("e2e-load-test-%s", state.GetCluster().Name)
+			configMapName := fmt.Sprintf("e2e-load-test-scenario-%s", state.GetCluster().Name)
+			cleanupK6Resources(testRunName, configMapName, k6Namespace)
+		}).
+		Run(t, "Performance Test")
+}

--- a/tests/performance/suites/mobilelatency/test_data/cluster_values.yaml
+++ b/tests/performance/suites/mobilelatency/test_data/cluster_values.yaml
@@ -1,0 +1,15 @@
+global:
+  apps:
+    certManager:
+      values:
+        config:
+          apiVersion: controller.config.cert-manager.io/v1alpha1
+          enableGatewayAPI: true
+          kind: ControllerConfiguration
+  connectivity:
+    certManager:
+      useDnsChallenges: true
+  nodePools:
+    def00:
+      minSize: 5
+      maxSize: 5

--- a/tests/performance/suites/mobilelatency/test_data/test-scenario.js
+++ b/tests/performance/suites/mobilelatency/test_data/test-scenario.js
@@ -1,0 +1,134 @@
+import http from "k6/http";
+import { check } from "k6";
+
+// Mobile latency-distribution replay. Ported from
+// cni-gateway-api-use-cases-k6/k6/static-use-cases/mobile-latency.js. It
+// reproduces a real production traffic mix (see MOBILE.md — a 17.6M-calls/hour
+// Kong sample) as five latency bands, each its own constant-arrival-rate
+// scenario driven at the band's measured RPS. The backend (go-httpbin) is told
+// to sleep per request via /delay/{seconds}, so the gateway has to juggle fast
+// and very slow upstreams concurrently — the point of the test.
+//
+// Mirrors the "basic" suite's Envoy-vs-reverse-proxy layout: the five envoy
+// bands run first, then the five reverse-proxy bands after a wait, so the two
+// don't synchronize. PROXY_CONTROLLER selects nginx or kong.
+
+const BASE_DOMAIN = __ENV.BASE_DOMAIN;
+const ENDPOINTS = parseInt(__ENV.ENDPOINTS || "10", 10);
+const PROXY_CONTROLLER = (__ENV.PROXY_CONTROLLER || "nginx").toLowerCase();
+if (PROXY_CONTROLLER !== "nginx" && PROXY_CONTROLLER !== "kong") {
+  throw new Error(`PROXY_CONTROLLER must be 'nginx' or 'kong' (got: '${PROXY_CONTROLLER}')`);
+}
+
+// Per-simulation duration (k6 duration string), the wait inserted before the
+// reverse-proxy simulation, and the factor that scales the production RPS down
+// to a test cluster.
+const RUN_DURATION = __ENV.RUN_DURATION || "20m";
+const WAIT_BETWEEN_SCENARIOS = parseInt(__ENV.WAIT_BETWEEN_SCENARIOS || "300", 10);
+const REDUCTION_RPS_FACTOR = Math.max(1, parseInt(__ENV.REDUCTION_RPS_FACTOR || "10", 10));
+const GRACEFUL_STOP = __ENV.GRACEFUL_STOP || "30s";
+
+const SLO_ERROR_RATE  = __ENV.SLO_ERROR_RATE  || "0.001"; // 0.1%
+const SLO_CHECKS_RATE = __ENV.SLO_CHECKS_RATE || "0.99";
+
+// httpbin is overlaid on the /delay path of the existing boutique hosts (so DNS
+// + TLS are reused). Envoy has one endpoint per loadtesting-{i} namespace, so
+// each request picks one at random to spread load across all of them, the way
+// the other suites' envoy scenarios do. nginx/kong each expose a single host.
+function envoyBaseUrl() {
+  const n = Math.floor(Math.random() * ENDPOINTS);
+  return `https://onlineboutique.loadtesting-${n}.${BASE_DOMAIN}`;
+}
+function nginxBaseUrl() { return `https://nginx-onlineboutique-0.loadtesting.${BASE_DOMAIN}`; }
+function kongBaseUrl()  { return `https://kong-onlineboutique.loadtesting.${BASE_DOMAIN}`; }
+function proxyBaseUrl() { return PROXY_CONTROLLER === "kong" ? kongBaseUrl() : nginxBaseUrl(); }
+
+// Latency bands (requests/second + injected delay in seconds), from
+// mobile-latency.js / MOBILE.md. go-httpbin is deployed with -max-duration=60s
+// so the 12s "over_10s" band is served faithfully (the default cap is 10s).
+const BANDS = [
+  { key: "fast_under_10ms", rps: 1666, delay: 0.005 },
+  { key: "under_100ms",     rps: 777,  delay: 0.05 },
+  { key: "under_200ms",     rps: 2194, delay: 0.2 },
+  { key: "under_10s",       rps: 222,  delay: 5 },
+  { key: "over_10s",        rps: 27,   delay: 12 },
+];
+
+function parseDurationSeconds(d) {
+  const m = /^(\d+)(ms|s|m|h)?$/.exec(String(d).trim());
+  if (!m) return 1200;
+  const value = parseInt(m[1], 10);
+  switch (m[2]) {
+    case "h": return value * 3600;
+    case "m": return value * 60;
+    case "ms": return Math.ceil(value / 1000);
+    default: return value; // "s" or bare number
+  }
+}
+
+// makeScenario mirrors the upstream VU sizing: for constant-arrival-rate the
+// concurrency needed is ~ rate * iteration_duration, with headroom so arrivals
+// aren't dropped. RPS is scaled down by REDUCTION_RPS_FACTOR.
+function makeScenario(exec, rps, delaySeconds, startTime, proxy) {
+  const rate = Math.max(1, Math.ceil(rps / REDUCTION_RPS_FACTOR));
+  const iterationSeconds = Math.max(0.5, delaySeconds);
+  const concurrency = Math.ceil(rate * iterationSeconds);
+  return {
+    executor: "constant-arrival-rate",
+    rate,
+    timeUnit: "1s",
+    duration: RUN_DURATION,
+    startTime,
+    preAllocatedVUs: Math.max(20, Math.ceil(concurrency * 1.25)),
+    maxVUs: Math.max(50, Math.ceil(concurrency * 8.0)),
+    gracefulStop: GRACEFUL_STOP,
+    exec,
+    tags: { proxy },
+  };
+}
+
+// Envoy runs first; the reverse proxy starts after Envoy's full duration plus
+// the wait window so request bursts don't overlap.
+const proxyStartTime = `${parseDurationSeconds(RUN_DURATION) + WAIT_BETWEEN_SCENARIOS}s`;
+
+const scenarios = {};
+const thresholds = {};
+for (const b of BANDS) {
+  const envoyExec = `envoy_${b.key}`;
+  const proxyExec = `proxy_${b.key}`;
+  scenarios[envoyExec] = makeScenario(envoyExec, b.rps, b.delay, "0s", "envoy");
+  scenarios[proxyExec] = makeScenario(proxyExec, b.rps, b.delay, proxyStartTime, PROXY_CONTROLLER);
+  for (const s of [envoyExec, proxyExec]) {
+    // Every completed request must be a 200; the injected delay means absolute
+    // latency thresholds aren't meaningful per band, so we gate on success rate
+    // and error rate (and that the band actually ran).
+    thresholds[`checks{scenario:${s}}`] = [`rate>${SLO_CHECKS_RATE}`];
+    thresholds[`http_req_failed{scenario:${s}}`] = [`rate<${SLO_ERROR_RATE}`];
+    thresholds[`http_reqs{scenario:${s}}`] = ["count>0"];
+  }
+}
+
+export const options = { scenarios, thresholds };
+
+// --- request ---------------------------------------------------------------
+
+function hitDelay(baseUrl, seconds) {
+  const res = http.get(`${baseUrl}/delay/${seconds}`);
+  check(res, {
+    "status is 200": (r) => r.status === 200,
+  });
+}
+
+// --- scenario entry points (one per band, per side) ------------------------
+
+export function envoy_fast_under_10ms() { hitDelay(envoyBaseUrl(), 0.005); }
+export function envoy_under_100ms()     { hitDelay(envoyBaseUrl(), 0.05); }
+export function envoy_under_200ms()     { hitDelay(envoyBaseUrl(), 0.2); }
+export function envoy_under_10s()       { hitDelay(envoyBaseUrl(), 5); }
+export function envoy_over_10s()        { hitDelay(envoyBaseUrl(), 12); }
+
+export function proxy_fast_under_10ms() { hitDelay(proxyBaseUrl(), 0.005); }
+export function proxy_under_100ms()     { hitDelay(proxyBaseUrl(), 0.05); }
+export function proxy_under_200ms()     { hitDelay(proxyBaseUrl(), 0.2); }
+export function proxy_under_10s()       { hitDelay(proxyBaseUrl(), 5); }
+export function proxy_over_10s()        { hitDelay(proxyBaseUrl(), 12); }


### PR DESCRIPTION
This PR add the `mobilelatency` performance test suite based on adidas eponymous use case. Instead of using microservices-demo app as a backend, it deploys `go-httpbin` as the actual backend and root every request to it. This allow for the creation of artificial delay/latency which is the goal of this test: reproducing the range of real-life latency experienced by Adidas' Kong. 

go-httpbin is deployed as a deployment and routes every incoming request to its service by deploying HTTPRoutes on each loadtesting-n namespaces (in Envoy case) that use the ListenerSets deployed on each on those namespaces as a parent.  

### Checklist

- [x] Update changelog in CHANGELOG.md.
