### PR TITLE
feat: set giantswarm-critical priorityClass on control plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Set `giantswarm-critical` priorityClass on the Envoy Gateway control plane pods.
 - Add `circuitBreaker` config field in bundle values for envoy performance test suites to better sustain high request load.
 - Move apps' versions in dependencies_test files from each performance test suite into a single file used in each of those.
 

--- a/diffs/helm__envoy-gateway__values.schema.json.patch
+++ b/diffs/helm__envoy-gateway__values.schema.json.patch
@@ -1,6 +1,6 @@
 diff --git a/helm/envoy-gateway/values.schema.json b/helm/envoy-gateway/values.schema.json
 new file mode 100644
-index 0000000..15b06bd
+index 0000000..04a0f5c
 --- /dev/null
 +++ b/helm/envoy-gateway/values.schema.json
 @@ -0,0 +1,498 @@
@@ -329,7 +329,7 @@ index 0000000..15b06bd
 +                    }
 +                },
 +                "priorityClassName": {
-+                    "type": "null"
++                    "type": ["string", "null"]
 +                },
 +                "replicas": {
 +                    "type": "integer"

--- a/diffs/helm__envoy-gateway__values.yaml.patch
+++ b/diffs/helm__envoy-gateway__values.yaml.patch
@@ -1,5 +1,5 @@
 diff --git a/vendor/gateway-helm/values.yaml b/helm/envoy-gateway/values.yaml
-index af43749..f4b691d 100644
+index af43749..c660390 100644
 --- a/vendor/gateway-helm/values.yaml
 +++ b/helm/envoy-gateway/values.yaml
 @@ -2,7 +2,8 @@
@@ -59,6 +59,15 @@ index af43749..f4b691d 100644
        seccompProfile:
          type: RuntimeDefault
    ports:
+@@ -83,7 +87,7 @@ deployment:
+     - name: metrics
+       port: 19001
+       targetPort: 19001
+-  priorityClassName: null
++  priorityClassName: giantswarm-critical
+   replicas: 1
+   pod:
+     affinity: {}
 @@ -149,7 +153,12 @@ certgen:
      pod:
        annotations: {}

--- a/helm/envoy-gateway/README.md
+++ b/helm/envoy-gateway/README.md
@@ -96,7 +96,7 @@ To uninstall the chart:
 | deployment.ports[3].name | string | `"metrics"` |  |
 | deployment.ports[3].port | int | `19001` |  |
 | deployment.ports[3].targetPort | int | `19001` |  |
-| deployment.priorityClassName | string | `nil` |  |
+| deployment.priorityClassName | string | `"giantswarm-critical"` |  |
 | deployment.replicas | int | `1` |  |
 | global.image | object | `{"registry":"gsoci.azurecr.io"}` | Global override for image registry |
 | global.imagePullSecrets | list | `[]` | Global override for image pull secrets |

--- a/helm/envoy-gateway/values.schema.json
+++ b/helm/envoy-gateway/values.schema.json
@@ -323,7 +323,7 @@
                     }
                 },
                 "priorityClassName": {
-                    "type": "null"
+                    "type": ["string", "null"]
                 },
                 "replicas": {
                     "type": "integer"

--- a/helm/envoy-gateway/values.yaml
+++ b/helm/envoy-gateway/values.yaml
@@ -87,7 +87,7 @@ deployment:
     - name: metrics
       port: 19001
       targetPort: 19001
-  priorityClassName: null
+  priorityClassName: giantswarm-critical
   replicas: 1
   pod:
     affinity: {}

--- a/sync/patches/values/values.schema.json
+++ b/sync/patches/values/values.schema.json
@@ -323,7 +323,7 @@
                     }
                 },
                 "priorityClassName": {
-                    "type": "null"
+                    "type": ["string", "null"]
                 },
                 "replicas": {
                     "type": "integer"

--- a/sync/patches/values/values.yaml
+++ b/sync/patches/values/values.yaml
@@ -87,7 +87,7 @@ deployment:
     - name: metrics
       port: 19001
       targetPort: 19001
-  priorityClassName: null
+  priorityClassName: giantswarm-critical
   replicas: 1
   pod:
     affinity: {}


### PR DESCRIPTION
## What

Set `giantswarm-critical` as the default `priorityClass` for the Envoy Gateway control plane pods. They previously ran with no priorityClass.

## Changes

- `sync/patches/values/values.yaml`: `deployment.priorityClassName: null` → `giantswarm-critical`
- `sync/patches/values/values.schema.json`: widen `priorityClassName` type to `["string", "null"]` so the default is valid while still allowing an override to `null`
- Regenerated `helm/` (values, schema, README) and `diffs/` via `sync/sync.sh`
- CHANGELOG entry under `[Unreleased]`

## Notes

- Scope is the control-plane deployment that this chart owns. The Envoy data-plane proxy pods are configured via the `EnvoyProxy` CR in `gateway-api-config-app`; a priorityClass there would be a separate change.

Towards https://github.com/giantswarm/giantswarm/issues/36991