### PR TITLE
feat(claude): add repo-specific claude skill

### DIFF
--- a/.claude/skills/perf-report/README.md
+++ b/.claude/skills/perf-report/README.md
@@ -1,0 +1,110 @@
+# perf-report skill
+
+Automates the "read the Grafana dashboards → write an HTML comparison report"
+step that follows a `/run envoy-performance-test` load test. Given a finished
+run, it queries the installation's Mimir with the **same PromQL the dashboards
+use**, then produces a self-contained HTML report and a PR summary comment.
+
+```text
+SKILL.md          orchestration Claude follows for /perf-report
+queries.yaml      PromQL manifest — source of truth, mirrored from the 3 dashboards
+fetch_metrics.py  Mimir → results.json (stdlib HTTP; needs PyYAML)
+render_report.py  results.json → report.html and/or a markdown PR summary
+```
+
+## Two run modes
+
+Same scripts, two environments. `fetch_metrics.py` auto-selects based on whether
+it is running inside a pod (`KUBERNETES_SERVICE_HOST`); override with `--mode` or
+an explicit `--mimir-url`.
+
+| Mode | When | Mimir URL | Reach |
+| --- | --- | --- | --- |
+| `local` | a human runs `/perf-report` in Claude Code | `http://localhost:8080` | `kubectl -n mimir port-forward svc/mimir-gateway 8080:80` |
+| `in-cluster` | Tekton pipeline pod on the MC | `http://mimir-gateway.mimir.svc/` | direct, no port-forward |
+
+Both modes may need the Mimir gateway's **basic-auth credentials** — the same
+`kube-system/alloy-metrics` creds the perf suite mirrors for remote-write. Pass
+them via `--username/--password` or `MIMIR_USERNAME`/`MIMIR_PASSWORD`:
+
+```bash
+export MIMIR_USERNAME=$(kubectl -n kube-system get secret alloy-metrics -o jsonpath='{.data.metrics-username}' | base64 -d)
+export MIMIR_PASSWORD=$(kubectl -n kube-system get secret alloy-metrics -o jsonpath='{.data.metrics-password}' | base64 -d)
+```
+
+### Local (Phase 1 — manual)
+
+Prereqs: `python3`, `pip install pyyaml`, `kubectl` context for the installation, `gh`.
+
+```bash
+kubectl config use-context <installation>
+kubectl -n mimir port-forward svc/mimir-gateway 8080:80 &      # background
+python3 fetch_metrics.py --cluster-id <wc> --output results.json   # mode auto=local
+python3 render_report.py --input results.json --output report.html
+python3 render_report.py --input results.json --format markdown --output summary.md
+```
+
+Or just run `/perf-report` in Claude Code and answer the prompts.
+
+### In-cluster (Phase 2 — Tekton)
+
+```bash
+python3 fetch_metrics.py --cluster-id <wc> --mode in-cluster --output results.json
+# ... render + gh pr comment, as above
+```
+
+### Inputs
+
+- `--cluster-id` (required): the `cluster_id` / `$workload_cluster` label.
+- `--testid`: defaults to `e2e-load-test-<cluster-id>`.
+- `--mode auto|local|in-cluster`: selects the default Mimir URL (default auto).
+- `--mimir-url`: explicit base URL; overrides `--mode`.
+- `--username`/`--password` (or `MIMIR_USERNAME`/`MIMIR_PASSWORD`): gateway basic auth.
+- `--competitor auto|nginx|kong`: auto-detected from the k6 scenarios by default.
+- `--lookback <hours>`: how far back to search for the run (default 6).
+- `--tenant` (default `giantswarm`): `X-Scope-OrgID` header.
+
+## Data flow it mirrors
+
+`/run envoy-performance-test` → Tekton runs the Ginkgo suite in `tests/performance`
+→ deploys Envoy Gateway + nginx **or** kong + the microservices demo → creates a
+k6 `TestRun`. k6 runs two staggered scenarios (`envoy_simulation`, then
+`nginx_simulation`/`kong_simulation`) and remote-writes to
+`mimir-gateway.mimir.svc/api/v1/push` tagged `testid=e2e-load-test-<cluster>`.
+Envoy/nginx/kong + cAdvisor metrics land in the same Mimir. The scripts query
+`…/prometheus/api/v1/query_range` with header `X-Scope-OrgID: giantswarm`.
+
+## Keeping queries in sync with the dashboards
+
+`queries.yaml` is copied from three dashboards in the `giantswarm/dashboards`
+repo (paths in the file header). When those dashboards change, diff their `expr`
+fields against `queries.yaml` and reconcile — keep expressions byte-identical so
+the report and Grafana never disagree. Quick extraction of a dashboard's exprs:
+
+```bash
+python3 -c 'import json,sys;d=json.load(open(sys.argv[1]));
+def w(ps):
+ for p in ps:
+  if p.get("panels"): w(p["panels"])
+  for t in p.get("targets",[]) or []:
+   if t.get("expr"): print(p.get("title"),"::"," ".join(t["expr"].split()))
+w(d["panels"])' <dashboard.json>
+```
+
+## Phase 2 — automate at pipeline end
+
+`/run` is a central Giant Swarm **Tekton** mechanism, not wired in this repo's
+`.github`. To make the report generate automatically when the TestRun finishes,
+add a step to the performance pipeline (in the Tekton pipeline definition, not
+here) that, after the suite passes:
+
+1. runs in a pod with in-cluster access to `mimir-gateway.mimir.svc` (no
+   port-forward needed — use `--mimir-url http://mimir-gateway.mimir.svc/`),
+2. runs `fetch_metrics.py` + `render_report.py` with the run's `cluster_id`,
+3. posts `summary.md` to the PR (the pipeline already knows the PR) and uploads
+   `report.html` as a pipeline artifact / gist.
+
+The scripts are dependency-light (Python 3 + PyYAML, stdlib HTTP) specifically so
+the same code runs unchanged in that pod. The cluster_id and PR number are known
+to the pipeline; pass them as args instead of prompting.
+```

--- a/.claude/skills/perf-report/SKILL.md
+++ b/.claude/skills/perf-report/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: perf-report
+description: >-
+  Generate an Envoy-Gateway-vs-competitor (nginx/kong) performance report from a
+  finished load test. Use after the `/run envoy-performance-test` pipeline
+  completes, or when the user asks for a "performance report", "perf report",
+  "envoy vs nginx report", "envoy vs kong report", or to summarize load-test /
+  k6 results into an HTML report and PR comment.
+---
+
+# Envoy Gateway performance report
+
+Turns a finished performance test (the `envoy-gateway-app` `tests/performance`
+suite) into a ready-to-read HTML report plus a PR summary comment, by querying
+the installation's Mimir with the same PromQL as the Grafana dashboards — no
+manual dashboard reading.
+
+The scripts live next to this file. `$DIR` below = the directory containing this
+`SKILL.md` (when installed as a plugin skill, that is the plugin's copy).
+
+## Pick the execution mode first
+
+This skill runs in one of two environments. Detect which and follow the matching
+path in step 2. `fetch_metrics.py` **auto-detects** the mode (it uses the
+in-cluster Mimir service when `KUBERNETES_SERVICE_HOST` is set, i.e. inside a
+pod, and localhost otherwise), so in practice you rarely pass `--mode`
+explicitly — but be deliberate about which environment you are in.
+
+- **Local (interactive)** — a human runs `/perf-report` in Claude Code on their
+  machine. Mimir is reached via a `kubectl port-forward`.
+- **In-cluster (Tekton)** — the pipeline spawns a headless agent in a pod on the
+  management cluster. Mimir is reached directly at `mimir-gateway.mimir.svc`,
+  with no port-forward. Inputs (cluster_id, PR number) arrive as arguments in
+  the invoking prompt, not by asking.
+
+## Inputs to collect
+
+- **cluster_id** — the workload cluster the test ran on (`cluster_id` /
+  `$workload_cluster` label).
+- **installation / MC** — the management cluster whose Mimir holds the metrics.
+  (Local mode: the kubeconfig context. In-cluster: already the pod's cluster.)
+- **PR number** — where `/run envoy-performance-test` was triggered, for posting.
+- optional: `testid` (default `e2e-load-test-<cluster_id>`), `competitor`
+  (`auto`|`nginx`|`kong`, default auto-detected), `lookback` hours (default 6).
+
+In **local** mode, ask the user for anything missing (never guess the cluster).
+In **in-cluster** mode, take them from the invocation prompt/args and fail
+loudly if absent — do not prompt an unattended pipeline.
+
+The competitor (nginx vs kong) and both scenario time windows are **always
+auto-detected** from the k6 series — never ask for them.
+
+## Mimir credentials (both modes)
+
+The Mimir gateway typically enforces basic auth — the same credentials the perf
+suite mirrors from `kube-system/alloy-metrics` for remote-write. Read them from
+the MC and pass them to the fetch script via env (works in both modes):
+
+```bash
+export MIMIR_USERNAME=$(kubectl -n kube-system get secret alloy-metrics -o jsonpath='{.data.metrics-username}' | base64 -d)
+export MIMIR_PASSWORD=$(kubectl -n kube-system get secret alloy-metrics -o jsonpath='{.data.metrics-password}' | base64 -d)
+```
+
+If a query returns 401/403, this step was missed. If the gateway is open for
+in-cluster traffic, the header is simply ignored — harmless to set anyway.
+
+## Steps
+
+Work in a scratch dir.
+
+1. **Credentials** — export `MIMIR_USERNAME`/`MIMIR_PASSWORD` as above.
+
+2. **Reach Mimir** — depending on mode:
+
+   **Local:**
+
+   ```bash
+   kubectl config use-context <installation-context>
+   kubectl -n mimir get svc mimir-gateway            # confirm it exists + the port
+   kubectl -n mimir port-forward svc/mimir-gateway 8080:80   # run in background
+   ```
+
+   Give the port-forward a second to establish. If the cluster isn't reachable,
+   stop and tell the user what's needed (VPN, teleport login, kubeconfig).
+   Prefer the kubernetes MCP tools if they're wired up for this installation.
+
+   **In-cluster (Tekton):** nothing to do — the service URL is reachable
+   directly. Skip the port-forward.
+
+3. **Fetch the metrics** (mode auto-detected; add `--mode` only to force it):
+
+   ```bash
+   # Local
+   python3 "$DIR/fetch_metrics.py" --cluster-id <cluster_id> \
+     --lookback 6 --output results.json
+   # In-cluster (equivalent to --mode in-cluster --mimir-url http://mimir-gateway.mimir.svc/)
+   python3 "$DIR/fetch_metrics.py" --cluster-id <cluster_id> \
+     --mode in-cluster --output results.json
+   ```
+
+   Requires `python3` + PyYAML (`pip install pyyaml` if missing). It prints the
+   chosen `mode`/`url`, the detected competitor, and both windows to stderr —
+   sanity-check that the windows look like real ~20-minute runs, not stray
+   seconds. If it reports no `envoy_simulation` data, widen `--lookback` or
+   re-check cluster_id/testid; the k6 metrics must still be within Mimir
+   retention.
+
+4. **Render the report + PR summary:**
+
+   ```bash
+   python3 "$DIR/render_report.py" --input results.json --output report.html
+   python3 "$DIR/render_report.py" --input results.json --format markdown --output summary.md
+   ```
+
+5. **Publish (if a PR number was given):**
+   - `gh` can't attach a file to a comment, so create a gist and link it:
+
+     ```bash
+     gh gist create report.html --public=false --desc "Envoy perf report <cluster_id>"
+     ```
+
+     Then re-render the markdown with the gist URL:
+     `render_report.py ... --format markdown --report-url <gist-url> --output summary.md`.
+   - Post the comment: `gh pr comment <pr> --body-file summary.md`.
+   - In-cluster, the pipeline may prefer uploading `report.html` as a pipeline
+     artifact instead of a gist — either is fine; still post `summary.md`.
+   - Always also report the local `report.html` path.
+
+6. **Clean up** the port-forward (local mode only).
+
+## Adding narrative
+
+The scripts produce the numbers, tables, charts, and a deterministic per-metric
+verdict. After generating them, read `results.json` and add 2–4 sentences of
+interpretation — where Envoy's latency advantage is largest, whether the
+CPU/memory trade-off is expected (Envoy typically uses more memory), and any SLO
+breaches (p95<500ms / p99<1000ms / error<0.1% — baked into the k6 scenario).
+Cite only values present in `results.json`; never invent numbers. In unattended
+in-cluster runs keep this brief and prepend it to the PR comment.
+
+## Notes / limits
+
+- The two scenarios run in **separate time windows** (Envoy first, competitor
+  after a wait). Charts overlay them on a common elapsed-time axis; they are not
+  concurrent traffic.
+- nginx exposes no upstream-latency histogram, so that comparison is Envoy-only
+  for nginx runs (kong has it). Expected, not a bug.
+- Latencies are normalized to milliseconds (Envoy/kong histograms are already ms;
+  nginx seconds ×1000), matching the dashboards.
+- `queries.yaml` is the source of truth for what's measured; keep it in sync with
+  the Grafana dashboards (see README.md).

--- a/.claude/skills/perf-report/fetch_metrics.py
+++ b/.claude/skills/perf-report/fetch_metrics.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Fetch Envoy-vs-competitor performance metrics from Mimir into results.json.
+
+Reads the PromQL manifest (queries.yaml), auto-detects the competitor
+(nginx/kong) and both k6 scenario windows from the k6 series, runs every query
+over the matching window, and writes a results.json consumed by render_report.py.
+
+HTTP uses only the standard library. The single third-party dependency is
+PyYAML (to parse queries.yaml):  pip install pyyaml
+
+Two modes, auto-selected (override with --mode / --mimir-url):
+  * local     — developer machine, via `kubectl -n mimir port-forward
+                svc/mimir-gateway 8080:80` -> http://localhost:8080
+  * in-cluster — Tekton pipeline pod on the MC -> http://mimir-gateway.mimir.svc/
+                (no port-forward; picked automatically when KUBERNETES_SERVICE_HOST
+                is set)
+
+    # local
+    python3 fetch_metrics.py --cluster-id my-wc --output results.json
+    # in-cluster (Tekton) — creds via env
+    MIMIR_USERNAME=... MIMIR_PASSWORD=... \
+      python3 fetch_metrics.py --cluster-id my-wc --output results.json
+
+The k6 testid defaults to  e2e-load-test-<cluster-id>  (see the perf suite).
+The Mimir gateway may require basic auth (same creds the perf suite mirrors from
+kube-system/alloy-metrics) — pass --username/--password or MIMIR_USERNAME/MIMIR_PASSWORD.
+"""
+import argparse
+import base64
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("PyYAML is required: pip install pyyaml")
+
+ENVOY_SCENARIO = "envoy_simulation"
+COMPETITOR_SCENARIOS = {"nginx_simulation": "nginx", "kong_simulation": "kong"}
+
+# In-cluster Mimir gateway (Tekton pipeline mode). Reachable without a
+# port-forward from any pod running in the management cluster.
+IN_CLUSTER_MIMIR_URL = "http://mimir-gateway.mimir.svc/"
+# Local mode: what `kubectl -n mimir port-forward svc/mimir-gateway 8080:80`
+# exposes on the developer's machine.
+LOCAL_MIMIR_URL = "http://localhost:8080"
+
+
+def running_in_cluster():
+    """True when executing inside a Kubernetes pod (e.g. the Tekton runner)."""
+    return bool(os.environ.get("KUBERNETES_SERVICE_HOST"))
+
+
+def build_headers(tenant, username, password):
+    """Mimir query headers: tenant scope + optional basic auth.
+
+    The gateway enforces the same basic auth the perf suite uses for
+    remote-write (mirrored from kube-system/alloy-metrics). Credentials come
+    from --username/--password or the MIMIR_USERNAME/MIMIR_PASSWORD env vars.
+    """
+    headers = {"X-Scope-OrgID": tenant}
+    username = username or os.environ.get("MIMIR_USERNAME")
+    password = password or os.environ.get("MIMIR_PASSWORD")
+    if username and password:
+        token = base64.b64encode(f"{username}:{password}".encode()).decode()
+        headers["Authorization"] = f"Basic {token}"
+    return headers
+
+
+# --------------------------------------------------------------------------- #
+# Mimir HTTP
+# --------------------------------------------------------------------------- #
+def _get(url, headers, timeout):
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode())
+
+
+def query_range(base, headers, expr, start, end, step, timeout=60):
+    """Run a range query; return list of {'labels':{}, 'points':[(ts,val)]}."""
+    qs = urllib.parse.urlencode(
+        {"query": expr, "start": f"{start:.3f}", "end": f"{end:.3f}", "step": f"{step}s"}
+    )
+    url = f"{base.rstrip('/')}/prometheus/api/v1/query_range?{qs}"
+    data = _get(url, headers, timeout)
+    if data.get("status") != "success":
+        raise RuntimeError(f"query failed: {data.get('error', data)}")
+    out = []
+    for series in data["data"]["result"]:
+        points = []
+        for ts, val in series.get("values", []):
+            try:
+                f = float(val)
+            except (TypeError, ValueError):
+                continue
+            if f != f:  # NaN
+                continue
+            points.append((float(ts), f))
+        out.append({"labels": series.get("metric", {}), "points": points})
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Aggregation
+# --------------------------------------------------------------------------- #
+def series_from_points(points, window_start):
+    """Turn raw (ts,val) points into a chartable series + summary stats.
+
+    x is seconds elapsed since the window start, so envoy and competitor series
+    (which ran in different absolute windows) overlay on a common elapsed axis.
+    """
+    t = [round(ts - window_start, 1) for ts, _ in points]
+    v = [val for _, val in points]
+    stats = {"mean": None, "max": None, "min": None, "last": None}
+    if v:
+        stats = {
+            "mean": sum(v) / len(v),
+            "max": max(v),
+            "min": min(v),
+            "last": v[-1],
+        }
+    return {"t": t, "v": v, "stats": stats}
+
+
+def merge_points(result):
+    """Flatten all series returned for one expr into a single point list.
+
+    Nearly every expr in the manifest aggregates to a single series; if more
+    than one comes back we sum by timestamp so the report still gets one line.
+    """
+    if not result:
+        return []
+    if len(result) == 1:
+        return result[0]["points"]
+    acc = {}
+    for s in result:
+        for ts, val in s["points"]:
+            acc[ts] = acc.get(ts, 0.0) + val
+    return sorted(acc.items())
+
+
+# --------------------------------------------------------------------------- #
+# Window / competitor detection
+# --------------------------------------------------------------------------- #
+def detect_scenarios(base, headers, testid, now, lookback_s, step=30):
+    """Find each k6 scenario's [start,end] window from k6_http_reqs_total."""
+    expr = f'sum by (scenario) (k6_http_reqs_total{{testid="{testid}"}})'
+    res = query_range(base, headers, expr, now - lookback_s, now, step)
+    windows = {}
+    for s in res:
+        scen = s["labels"].get("scenario")
+        pts = s["points"]
+        if not scen or not pts:
+            continue
+        windows[scen] = (pts[0][0], pts[-1][0])
+    return windows
+
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+def run_side(base, headers, spec, cluster_id, testid, rate, window, side_key):
+    """Run one metric's queries for one side (envoy or competitor)."""
+    start, end = window
+    step = max(15, int((end - start) / 200))
+
+    def fmt(expr):
+        return (
+            expr.replace("{cluster_id}", cluster_id)
+            .replace("{testid}", testid)
+            .replace("{rate}", rate)
+        )
+
+    if spec.get("kind") == "percentile":
+        block = spec.get(side_key)
+        if not block:
+            return None  # e.g. nginx has no upstream-latency histogram
+        out = {}
+        for p, expr in block.items():
+            pts = merge_points(query_range(base, headers, fmt(expr), start, end, step))
+            out[p] = series_from_points(pts, start)
+        return {"kind": "percentile", "percentiles": out}
+    else:
+        expr = spec.get(side_key)
+        if not expr:
+            return None
+        pts = merge_points(query_range(base, headers, fmt(expr), start, end, step))
+        return {"kind": "single", "series": series_from_points(pts, start)}
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--cluster-id", required=True, help="workload cluster_id")
+    ap.add_argument("--testid", help="k6 testid (default: e2e-load-test-<cluster-id>)")
+    ap.add_argument("--mode", choices=["auto", "local", "in-cluster"], default="auto",
+                    help="local = port-forward on localhost; in-cluster = mimir-gateway.mimir.svc "
+                         "(Tekton). 'auto' picks in-cluster when running inside a pod.")
+    ap.add_argument("--mimir-url", default=None,
+                    help="explicit Mimir gateway base URL; overrides --mode")
+    ap.add_argument("--tenant", default="giantswarm", help="X-Scope-OrgID header")
+    ap.add_argument("--username", default=None,
+                    help="Mimir basic-auth user (or env MIMIR_USERNAME); "
+                         "mirrors kube-system/alloy-metrics metrics-username")
+    ap.add_argument("--password", default=None,
+                    help="Mimir basic-auth password (or env MIMIR_PASSWORD); "
+                         "mirrors kube-system/alloy-metrics metrics-password")
+    ap.add_argument("--competitor", choices=["auto", "nginx", "kong"], default="auto")
+    ap.add_argument("--lookback", type=float, default=6.0, help="hours to search for the run")
+    ap.add_argument("--now", type=float, default=None,
+                    help="reference unix time (default: real now)")
+    ap.add_argument("--queries", default=None, help="path to queries.yaml")
+    ap.add_argument("--output", default="results.json")
+    args = ap.parse_args()
+
+    import os
+    qpath = args.queries or os.path.join(os.path.dirname(os.path.abspath(__file__)), "queries.yaml")
+    with open(qpath) as f:
+        manifest = yaml.safe_load(f)
+    rate = manifest.get("rate_interval", "5m")
+
+    testid = args.testid or f"e2e-load-test-{args.cluster_id}"
+
+    # Resolve the Mimir URL: explicit --mimir-url wins; else derive from --mode
+    # (auto = in-cluster when running inside a pod, local otherwise).
+    if args.mimir_url:
+        base, mode = args.mimir_url, "explicit"
+    else:
+        mode = args.mode
+        if mode == "auto":
+            mode = "in-cluster" if running_in_cluster() else "local"
+        base = IN_CLUSTER_MIMIR_URL if mode == "in-cluster" else LOCAL_MIMIR_URL
+
+    headers = build_headers(args.tenant, args.username, args.password)
+    auth = "with basic auth" if "Authorization" in headers else "no auth"
+    print(f"Mimir mode={mode} url={base} ({auth})", file=sys.stderr)
+
+    now = args.now if args.now is not None else datetime.now(timezone.utc).timestamp()
+    lookback_s = args.lookback * 3600
+
+    print(f"Detecting k6 scenarios for testid={testid} ...", file=sys.stderr)
+    windows = detect_scenarios(base, headers, testid, now, lookback_s)
+    if ENVOY_SCENARIO not in windows:
+        sys.exit(f"No '{ENVOY_SCENARIO}' data found for testid={testid} in the last "
+                 f"{args.lookback}h. Check --cluster-id/--testid/--lookback and connectivity.")
+
+    # Resolve competitor
+    comp_scen = None
+    for scen in windows:
+        if scen in COMPETITOR_SCENARIOS:
+            comp_scen = scen
+            break
+    if args.competitor != "auto":
+        want = f"{args.competitor}_simulation"
+        comp_scen = want if want in windows else comp_scen
+    if not comp_scen:
+        sys.exit(f"No competitor scenario (nginx/kong) found. Scenarios seen: {list(windows)}")
+    competitor = COMPETITOR_SCENARIOS[comp_scen]
+
+    envoy_win = windows[ENVOY_SCENARIO]
+    comp_win = windows[comp_scen]
+    print(f"  envoy window : {_fmt_win(envoy_win)}", file=sys.stderr)
+    print(f"  {competitor} window : {_fmt_win(comp_win)}", file=sys.stderr)
+
+    results = {
+        "meta": {
+            "cluster_id": args.cluster_id,
+            "testid": testid,
+            "competitor": competitor,
+            "mode": mode,
+            "rate_interval": rate,
+            "envoy_window": {"start": envoy_win[0], "end": envoy_win[1],
+                             "duration_s": round(envoy_win[1] - envoy_win[0])},
+            "competitor_window": {"start": comp_win[0], "end": comp_win[1],
+                                  "duration_s": round(comp_win[1] - comp_win[0])},
+        },
+        "k6": {"envoy": {}, "competitor": {}},
+        "comparison": {},
+    }
+
+    # k6 client-side metrics per scenario
+    for key, spec in manifest.get("k6", {}).items():
+        for side, scen, win in (("envoy", ENVOY_SCENARIO, envoy_win),
+                                ("competitor", comp_scen, comp_win)):
+            expr = (spec["expr"].replace("{testid}", testid)
+                    .replace("{scenario}", scen).replace("{rate}", rate))
+            pts = merge_points(query_range(base, headers, expr, win[0], win[1],
+                                           max(15, int((win[1] - win[0]) / 200))))
+            s = series_from_points(pts, win[0])
+            results["k6"][side][key] = {"title": spec["title"], "unit": spec["unit"], **s}
+
+    # Server-side comparison metrics
+    for key, spec in manifest.get("comparison", {}).items():
+        entry = {
+            "title": spec["title"], "unit": spec["unit"],
+            "kind": spec.get("kind", "single"),
+            "lower_is_better": spec.get("lower_is_better", True),
+        }
+        entry["envoy"] = run_side(base, headers, spec, args.cluster_id, testid, rate,
+                                  envoy_win, "envoy")
+        entry["competitor"] = run_side(base, headers, spec, args.cluster_id, testid, rate,
+                                       comp_win, competitor)
+        results["comparison"][key] = entry
+        print(f"  fetched {key}", file=sys.stderr)
+
+    with open(args.output, "w") as f:
+        json.dump(results, f, indent=2)
+    print(f"Wrote {args.output} (competitor={competitor})", file=sys.stderr)
+
+
+def _fmt_win(w):
+    return (f"{datetime.fromtimestamp(w[0], timezone.utc):%H:%M:%S}"
+            f"–{datetime.fromtimestamp(w[1], timezone.utc):%H:%M:%S} UTC "
+            f"({round(w[1]-w[0])}s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/perf-report/queries.yaml
+++ b/.claude/skills/perf-report/queries.yaml
@@ -1,0 +1,127 @@
+# PromQL manifest for the Envoy Gateway performance report.
+#
+# This is the SOURCE OF TRUTH for what the report measures. It is mirrored from
+# the three Grafana dashboards (in the giantswarm/dashboards repo):
+#   * charts/networking/dashboards/Shared Org/k6-tests-results.json
+#   * charts/networking/dashboards/Shared Org/Envoy Gateway/envoy-vs-nginx-loadtesting.json
+#   * charts/networking/dashboards/Shared Org/Envoy Gateway/envoy-vs-kong-loadtesting.json
+#
+# Placeholders substituted by fetch_metrics.py:
+#   {cluster_id}  -> the workload cluster_id ($workload_cluster in the dashboards)
+#   {testid}      -> the k6 testid  ($testid in the k6 dashboard), e.g. e2e-load-test-<cluster>
+#   {rate}        -> rate window (default 5m, matching the dashboards)
+#
+# When the dashboards change, re-run:  python3 fetch_metrics.py --dump-dashboard-queries
+# (see README.md) and reconcile this file. Keep expressions byte-identical to the
+# dashboards so the report and Grafana never disagree.
+
+rate_interval: "5m"
+
+# --- k6 client-side metrics, per scenario -----------------------------------
+# Queried per scenario over that scenario's own window. {scenario} is one of
+# envoy_simulation / nginx_simulation / kong_simulation.
+# k6 values are already summary quantiles (p95/p99) in milliseconds.
+k6:
+  http_req_duration_p99:
+    title: "HTTP req duration p99"
+    unit: ms
+    expr: 'avg(k6_http_req_duration_p99{testid="{testid}", scenario="{scenario}"})'
+  http_req_duration_p95:
+    title: "HTTP req duration p95"
+    unit: ms
+    expr: 'avg(k6_http_req_duration_p95{testid="{testid}", scenario="{scenario}"})'
+  http_reqs_rate:
+    title: "HTTP request rate"
+    unit: req/s
+    expr: 'sum(irate(k6_http_reqs_total{testid="{testid}", scenario="{scenario}"}[{rate}]))'
+  http_req_failed_rate:
+    title: "HTTP failure rate"
+    unit: ratio
+    expr: 'avg(k6_http_req_failed_rate{testid="{testid}", scenario="{scenario}"})'
+  checks_rate:
+    title: "Checks success rate"
+    unit: ratio
+    expr: 'avg(k6_checks_rate{testid="{testid}", scenario="{scenario}"})'
+  iterations:
+    title: "Iterations completed"
+    unit: count
+    expr: 'sum(k6_iterations_total{testid="{testid}", scenario="{scenario}"})'
+  dropped_iterations:
+    title: "Dropped iterations"
+    unit: count
+    expr: 'sum(k6_dropped_iterations_total{testid="{testid}", scenario="{scenario}"})'
+
+# --- Server-side comparison metrics -----------------------------------------
+# Each metric has an `envoy` block and one block per competitor (nginx / kong).
+# fetch_metrics.py picks the envoy block + the detected competitor's block, runs
+# each over the matching scenario window, and pairs them in the report.
+# `kind: percentile` means the sub-keys (p50/p90/p99) are separate series.
+comparison:
+
+  downstream_latency:
+    title: "Downstream latency"
+    unit: ms
+    kind: percentile
+    envoy:
+      p50: 'histogram_quantile(0.5, sum by(le) (rate(envoy_http_downstream_rq_time_bucket{cluster_id="{cluster_id}"}[{rate}])))'
+      p90: 'histogram_quantile(0.9, sum by(le) (rate(envoy_http_downstream_rq_time_bucket{cluster_id="{cluster_id}"}[{rate}])))'
+      p99: 'histogram_quantile(0.99, sum by(le) (rate(envoy_http_downstream_rq_time_bucket{cluster_id="{cluster_id}"}[{rate}])))'
+    nginx:
+      p50: 'histogram_quantile(0.5, sum by(le) (rate(nginx_ingress_controller_request_duration_seconds_bucket{cluster_id="{cluster_id}"}[{rate}]))) * 1000'
+      p90: 'histogram_quantile(0.9, sum by(le) (rate(nginx_ingress_controller_request_duration_seconds_bucket{cluster_id="{cluster_id}"}[{rate}]))) * 1000'
+      p99: 'histogram_quantile(0.99, sum by(le) (rate(nginx_ingress_controller_request_duration_seconds_bucket{cluster_id="{cluster_id}"}[{rate}]))) * 1000'
+    kong:
+      p50: 'histogram_quantile(0.5, sum by(le) (rate(kong_kong_latency_ms_bucket{cluster_id="{cluster_id}"}[{rate}])))'
+      p90: 'histogram_quantile(0.9, sum by(le) (rate(kong_kong_latency_ms_bucket{cluster_id="{cluster_id}"}[{rate}])))'
+      p99: 'histogram_quantile(0.99, sum by(le) (rate(kong_kong_latency_ms_bucket{cluster_id="{cluster_id}"}[{rate}])))'
+
+  downstream_rps:
+    title: "Downstream RPS"
+    unit: req/s
+    kind: single
+    lower_is_better: false
+    envoy: 'sum(rate(envoy_http_downstream_rq_total{cluster_id="{cluster_id}"}[{rate}]))'
+    nginx: 'sum(rate(nginx_ingress_controller_requests{cluster_id="{cluster_id}",controller_namespace="kube-system"}[{rate}]))'
+    kong: 'sum(rate(kong_kong_latency_ms_count{cluster_id="{cluster_id}"}[{rate}]))'
+
+  success_rate:
+    title: "Downstream success rate"
+    unit: "%"
+    kind: single
+    lower_is_better: false
+    envoy: 'sum(rate(envoy_http_downstream_rq_xx{cluster_id="{cluster_id}", envoy_response_code_class!~"4|5"}[{rate}])) by (cluster_id) / sum(rate(envoy_http_downstream_rq_xx{cluster_id="{cluster_id}"}[{rate}])) by (cluster_id) * 100'
+    nginx: 'sum(rate(nginx_ingress_controller_requests{cluster_id="{cluster_id}", status!~"[4-5].*"}[{rate}])) by (cluster_id) / sum(rate(nginx_ingress_controller_requests{cluster_id="{cluster_id}"}[{rate}])) by (cluster_id) * 100'
+    kong: 'sum(rate(kong_kong_latency_ms_count{cluster_id="{cluster_id}", code!~"[45].."}[{rate}])) by (cluster_id) / sum(rate(kong_kong_latency_ms_count{cluster_id="{cluster_id}"}[{rate}])) by (cluster_id) * 100'
+
+  upstream_latency:
+    title: "Upstream latency"
+    unit: ms
+    kind: percentile
+    envoy:
+      p50: 'histogram_quantile(0.5, sum(rate(envoy_cluster_upstream_rq_time_bucket{cluster_id="{cluster_id}", namespace="envoy-gateway-system"}[{rate}])) by (le, namespace))'
+      p90: 'histogram_quantile(0.9, sum(rate(envoy_cluster_upstream_rq_time_bucket{cluster_id="{cluster_id}", namespace="envoy-gateway-system"}[{rate}])) by (le, namespace))'
+      p99: 'histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_rq_time_bucket{cluster_id="{cluster_id}", namespace="envoy-gateway-system"}[{rate}])) by (le, namespace))'
+    kong:
+      p50: 'histogram_quantile(0.5, sum(rate(kong_upstream_latency_ms_bucket{cluster_id="{cluster_id}", namespace="kong"}[{rate}])) by (le, namespace))'
+      p90: 'histogram_quantile(0.9, sum(rate(kong_upstream_latency_ms_bucket{cluster_id="{cluster_id}", namespace="kong"}[{rate}])) by (le, namespace))'
+      p99: 'histogram_quantile(0.99, sum(rate(kong_upstream_latency_ms_bucket{cluster_id="{cluster_id}", namespace="kong"}[{rate}])) by (le, namespace))'
+    # nginx: upstream latency exposed only as a request count (no histogram) on
+    # the nginx dashboard, so there is no comparable percentile series. Omitted.
+
+  cpu_usage:
+    title: "CPU usage"
+    unit: cores
+    kind: single
+    lower_is_better: true
+    envoy: 'sum(max by (cluster_id, namespace, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{cluster_id="{cluster_id}", namespace="envoy-gateway-system"}) * on(cluster_id, namespace, pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster_id="{cluster_id}", namespace="envoy-gateway-system", workload_type="deployment"}) by (cluster_id)'
+    nginx: 'sum(max by (cluster_id, namespace, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{cluster_id="{cluster_id}", namespace="kube-system"}) * on(cluster_id, namespace, pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster_id="{cluster_id}", namespace="kube-system", workload="ingress-nginx-controller", workload_type="deployment"}) by (workload)'
+    kong: 'sum(max by (cluster_id, namespace, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{cluster_id="{cluster_id}", namespace="kong"}) * on(cluster_id, namespace, pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster_id="{cluster_id}", namespace="kong", workload="kong-app-kong-app", workload_type="deployment"}) by (workload)'
+
+  memory_usage:
+    title: "Memory usage"
+    unit: bytes
+    kind: single
+    lower_is_better: true
+    envoy: 'sum(max by (cluster_id, namespace, pod, container)(container_memory_working_set_bytes{cluster_id="{cluster_id}", namespace="envoy-gateway-system", container!="", image!=""}) * on(cluster_id, namespace, pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster_id="{cluster_id}", namespace="envoy-gateway-system", workload_type="deployment"}) by (cluster_id)'
+    nginx: 'sum(max by (cluster_id, namespace, pod, container)(container_memory_working_set_bytes{cluster_id="{cluster_id}", namespace="kube-system", container!="", image!=""}) * on(cluster_id, namespace, pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster_id="{cluster_id}", namespace="kube-system", workload="ingress-nginx-controller", workload_type="deployment"}) by (workload)'
+    kong: 'sum(max by (cluster_id, namespace, pod, container)(container_memory_working_set_bytes{cluster_id="{cluster_id}", namespace="kong", container!="", image!=""}) * on(cluster_id, namespace, pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster_id="{cluster_id}", namespace="kong", workload="kong-app-kong-app", workload_type="deployment"}) by (workload)'

--- a/.claude/skills/perf-report/render_report.py
+++ b/.claude/skills/perf-report/render_report.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""Render results.json (from fetch_metrics.py) into a self-contained HTML report.
+
+    python3 render_report.py --input results.json --output report.html
+
+No third-party dependencies, no external assets: charts are inline SVG so the
+file works as a standalone artifact (e.g. attached to a PR) with no network.
+"""
+import argparse
+import html
+import json
+from datetime import datetime, timezone
+
+ENVOY = "#2563eb"   # blue
+COMPET = "#f97316"  # orange
+P_COLORS = {"p50": "#94a3b8", "p90": "#38bdf8", "p99": "#2563eb"}
+
+
+# --------------------------------------------------------------------------- #
+# Value formatting
+# --------------------------------------------------------------------------- #
+def fmt(unit, x):
+    if x is None:
+        return "—"
+    if unit == "bytes":
+        return f"{x / 1024 / 1024:.1f} MiB"
+    if unit == "ms":
+        return f"{x:.1f} ms"
+    if unit == "cores":
+        return f"{x:.3f}"
+    if unit in ("%",):
+        return f"{x:.2f} %"
+    if unit == "ratio":
+        return f"{x * 100:.2f} %"
+    if unit == "req/s":
+        return f"{x:.1f} req/s"
+    if unit == "count":
+        return f"{x:,.0f}"
+    return f"{x:.2f}"
+
+
+def pct_delta(a, b):
+    """Signed relative change of a vs b, as a % string."""
+    if a is None or b is None or b == 0:
+        return "—"
+    return f"{(a - b) / abs(b) * 100:+.1f}%"
+
+
+# --------------------------------------------------------------------------- #
+# SVG line chart
+# --------------------------------------------------------------------------- #
+def svg_chart(series, unit, width=680, height=240):
+    """series: list of {name, color, t:[...], v:[...]}. Returns an <svg> string."""
+    pad_l, pad_r, pad_t, pad_b = 56, 12, 12, 30
+    plotted = [s for s in series if s["t"] and s["v"]]
+    if not plotted:
+        return '<div class="empty">no data</div>'
+
+    xs = [x for s in plotted for x in s["t"]]
+    ys = [y for s in plotted for y in s["v"]]
+    xmin, xmax = min(xs), max(xs)
+    ymin, ymax = min(ys), max(ys)
+    if ymin == ymax:
+        ymin, ymax = (0, ymax * 1.5 or 1)
+    else:
+        ymin = min(ymin, 0) if ymin > 0 else ymin
+    xspan = (xmax - xmin) or 1
+    yspan = (ymax - ymin) or 1
+
+    def px(x):
+        return pad_l + (x - xmin) / xspan * (width - pad_l - pad_r)
+
+    def py(y):
+        return height - pad_b - (y - ymin) / yspan * (height - pad_t - pad_b)
+
+    parts = [f'<svg viewBox="0 0 {width} {height}" class="chart" '
+             f'preserveAspectRatio="xMidYMid meet" role="img">']
+
+    # y gridlines + labels (4 steps)
+    for i in range(5):
+        yv = ymin + yspan * i / 4
+        y = py(yv)
+        parts.append(f'<line x1="{pad_l}" y1="{y:.1f}" x2="{width-pad_r}" y2="{y:.1f}" '
+                     f'class="grid"/>')
+        parts.append(f'<text x="{pad_l-6}" y="{y+3:.1f}" class="ylab">{_short(yv)}</text>')
+    # x labels (start / mid / end elapsed seconds)
+    for frac in (0, 0.5, 1):
+        xv = xmin + xspan * frac
+        x = px(xv)
+        parts.append(f'<text x="{x:.1f}" y="{height-8}" class="xlab">{xv:.0f}s</text>')
+
+    for s in plotted:
+        pts = " ".join(f"{px(x):.1f},{py(y):.1f}" for x, y in zip(s["t"], s["v"]))
+        parts.append(f'<polyline points="{pts}" fill="none" stroke="{s["color"]}" '
+                     f'stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>')
+        # emphasized endpoint
+        ex, ey = px(s["t"][-1]), py(s["v"][-1])
+        parts.append(f'<circle cx="{ex:.1f}" cy="{ey:.1f}" r="3.2" fill="{s["color"]}"/>')
+    parts.append("</svg>")
+    return "".join(parts)
+
+
+def _short(x):
+    ax = abs(x)
+    if ax >= 1e9:
+        return f"{x/1e9:.1f}G"
+    if ax >= 1e6:
+        return f"{x/1e6:.1f}M"
+    if ax >= 1e3:
+        return f"{x/1e3:.1f}k"
+    if ax >= 1 or x == 0:
+        return f"{x:.0f}"
+    return f"{x:.2f}"
+
+
+def legend(items):
+    chips = "".join(
+        f'<span class="chip"><i style="background:{c}"></i>{html.escape(n)}</span>'
+        for n, c in items)
+    return f'<div class="legend">{chips}</div>'
+
+
+# --------------------------------------------------------------------------- #
+# Representative value + verdict per comparison metric
+# --------------------------------------------------------------------------- #
+def representative(side):
+    """Pick the headline scalar for a side of a comparison metric."""
+    if side is None:
+        return None
+    if side["kind"] == "percentile":
+        p99 = side["percentiles"].get("p99")
+        return p99["stats"]["mean"] if p99 else None
+    return side["series"]["stats"]["mean"]
+
+
+# --------------------------------------------------------------------------- #
+# HTML assembly
+# --------------------------------------------------------------------------- #
+def render(data):
+    meta = data["meta"]
+    comp = meta["competitor"]
+    comp_title = comp.capitalize()
+
+    def side_name(side):
+        return "Envoy" if side == "envoy" else comp_title
+
+    rows, sections = [], []
+    envoy_wins = comp_wins = 0
+
+    for key, entry in data["comparison"].items():
+        e_val = representative(entry["envoy"])
+        c_val = representative(entry["competitor"])
+        unit = entry["unit"]
+        winner = None
+        if e_val is not None and c_val is not None:
+            lb = entry["lower_is_better"]
+            envoy_better = (e_val < c_val) if lb else (e_val > c_val)
+            winner = "Envoy" if envoy_better else comp_title
+            envoy_wins += int(envoy_better)
+            comp_wins += int(not envoy_better)
+
+        label = entry["title"] + (" (p99)" if entry["kind"] == "percentile" else "")
+        rows.append(
+            f"<tr><td>{html.escape(label)}</td>"
+            f"<td class='num'>{fmt(unit, e_val)}</td>"
+            f"<td class='num'>{fmt(unit, c_val)}</td>"
+            f"<td class='num'>{pct_delta(e_val, c_val)}</td>"
+            f"<td class='win {'envoy' if winner=='Envoy' else 'comp'}'>{winner or '—'}</td></tr>"
+        )
+
+        # chart + per-metric detail
+        if entry["kind"] == "percentile":
+            e_series, c_series = [], []
+            detail_rows = []
+            for p in ("p50", "p90", "p99"):
+                ep = entry["envoy"]["percentiles"].get(p) if entry["envoy"] else None
+                cp = entry["competitor"]["percentiles"].get(p) if entry["competitor"] else None
+                em = ep["stats"]["mean"] if ep else None
+                cm = cp["stats"]["mean"] if cp else None
+                detail_rows.append(
+                    f"<tr><td>{p}</td><td class='num'>{fmt(unit, em)}</td>"
+                    f"<td class='num'>{fmt(unit, cm)}</td>"
+                    f"<td class='num'>{pct_delta(em, cm)}</td></tr>")
+            e99 = entry["envoy"]["percentiles"].get("p99") if entry["envoy"] else None
+            c99 = entry["competitor"]["percentiles"].get("p99") if entry["competitor"] else None
+            chart_series = []
+            if e99:
+                chart_series.append({"name": "Envoy p99", "color": ENVOY, **e99})
+            if c99:
+                chart_series.append({"name": f"{comp_title} p99", "color": COMPET, **c99})
+            leg = legend([("Envoy p99", ENVOY), (f"{comp_title} p99", COMPET)])
+            detail = (f"<table class='mini'><tr><th></th><th class='num'>Envoy</th>"
+                      f"<th class='num'>{comp_title}</th><th class='num'>Δ</th></tr>"
+                      f"{''.join(detail_rows)}</table>")
+            body = (leg + svg_chart(chart_series, unit) + detail)
+        else:
+            es = entry["envoy"]["series"] if entry["envoy"] else None
+            cs = entry["competitor"]["series"] if entry["competitor"] else None
+            chart_series = []
+            if es:
+                chart_series.append({"name": "Envoy", "color": ENVOY, **es})
+            if cs:
+                chart_series.append({"name": comp_title, "color": COMPET, **cs})
+            leg = legend([("Envoy", ENVOY), (comp_title, COMPET)])
+            stat = (f"<table class='mini'><tr><th></th><th class='num'>mean</th><th class='num'>peak</th></tr>"
+                    f"<tr><td>Envoy</td><td class='num'>{fmt(unit, es['stats']['mean'] if es else None)}</td>"
+                    f"<td class='num'>{fmt(unit, es['stats']['max'] if es else None)}</td></tr>"
+                    f"<tr><td>{comp_title}</td><td class='num'>{fmt(unit, cs['stats']['mean'] if cs else None)}</td>"
+                    f"<td class='num'>{fmt(unit, cs['stats']['max'] if cs else None)}</td></tr></table>")
+            body = leg + svg_chart(chart_series, unit) + stat
+
+        sections.append(
+            f"<section class='metric'><h3>{html.escape(entry['title'])} "
+            f"<span class='unit'>({html.escape(unit)})</span></h3>{body}</section>")
+
+    # k6 client-side table
+    k6_rows = []
+    all_keys = list(data["k6"]["envoy"].keys())
+    for k in all_keys:
+        em = data["k6"]["envoy"][k]
+        cm = data["k6"]["competitor"].get(k, {})
+        title, unit = em["title"], em["unit"]
+        ev = em["stats"]["mean"]
+        cv = cm.get("stats", {}).get("mean")
+        # counts (iterations) use last/total rather than mean
+        if unit == "count":
+            ev = em["stats"]["last"]
+            cv = cm.get("stats", {}).get("last")
+        k6_rows.append(
+            f"<tr><td>{html.escape(title)}</td>"
+            f"<td class='num'>{fmt(unit, ev)}</td>"
+            f"<td class='num'>{fmt(unit, cv)}</td></tr>")
+
+    overall = ("Envoy leads on the majority of server-side metrics."
+               if envoy_wins > comp_wins else
+               f"{comp_title} leads on the majority of server-side metrics."
+               if comp_wins > envoy_wins else "Envoy and the competitor are evenly matched.")
+
+    generated = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    ew = meta["envoy_window"]
+    cw = meta["competitor_window"]
+
+    return TEMPLATE.format(
+        comp_title=comp_title,
+        cluster_id=html.escape(meta["cluster_id"]),
+        testid=html.escape(meta["testid"]),
+        generated=generated,
+        rate=html.escape(meta["rate_interval"]),
+        envoy_dur=ew["duration_s"], comp_dur=cw["duration_s"],
+        overall=html.escape(overall),
+        envoy_wins=envoy_wins, comp_wins=comp_wins,
+        summary_rows="".join(rows),
+        sections="".join(sections),
+        k6_rows="".join(k6_rows),
+        css=CSS,
+    )
+
+
+CSS = """
+:root{
+  --bg:#f7f8fa;--card:#ffffff;--fg:#111927;--muted:#5c6b7f;--line:#e3e8ef;
+  --th-bg:#f1f4f8;--e-bg:#dbeafe;--e-fg:#1e40af;--c-bg:#ffedd5;--c-fg:#9a3412;
+  --shadow:0 1px 2px rgba(17,25,39,.05),0 1px 3px rgba(17,25,39,.04);
+}
+@media (prefers-color-scheme:dark){
+  :root{
+    --bg:#0f1419;--card:#1a212b;--fg:#e6edf3;--muted:#93a1b3;--line:#28323f;
+    --th-bg:#212b37;--e-bg:#17314f;--e-fg:#9dc3ff;--c-bg:#43290f;--c-fg:#ffc08a;
+    --shadow:0 1px 2px rgba(0,0,0,.4);
+  }
+}
+:root[data-theme="light"]{
+  --bg:#f7f8fa;--card:#ffffff;--fg:#111927;--muted:#5c6b7f;--line:#e3e8ef;
+  --th-bg:#f1f4f8;--e-bg:#dbeafe;--e-fg:#1e40af;--c-bg:#ffedd5;--c-fg:#9a3412;
+  --shadow:0 1px 2px rgba(17,25,39,.05),0 1px 3px rgba(17,25,39,.04);
+}
+:root[data-theme="dark"]{
+  --bg:#0f1419;--card:#1a212b;--fg:#e6edf3;--muted:#93a1b3;--line:#28323f;
+  --th-bg:#212b37;--e-bg:#17314f;--e-fg:#9dc3ff;--c-bg:#43290f;--c-fg:#ffc08a;
+  --shadow:0 1px 2px rgba(0,0,0,.4);
+}
+*{box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+color:var(--fg);background:var(--bg);margin:0;padding:0;line-height:1.5;
+-webkit-font-smoothing:antialiased}
+.wrap{max-width:980px;margin:0 auto;padding:40px 22px 72px}
+h1{font-size:27px;font-weight:700;letter-spacing:-.01em;margin:0 0 3px;text-wrap:balance}
+h2{font-size:14px;font-weight:600;text-transform:uppercase;letter-spacing:.06em;
+color:var(--muted);margin:40px 0 14px;padding-bottom:8px;border-bottom:1px solid var(--line)}
+h3{font-size:15px;font-weight:600;margin:0 0 12px}
+.sub{color:var(--muted);font-size:13px}
+.meta{display:flex;flex-wrap:wrap;gap:6px 22px;margin:18px 0;font-size:12.5px;color:var(--muted)}
+.meta b{color:var(--fg);font-weight:600}
+.verdict{background:var(--card);border:1px solid var(--line);border-radius:12px;
+padding:18px 20px;margin:22px 0;box-shadow:var(--shadow)}
+.verdict .big{font-size:17px;font-weight:650;letter-spacing:-.01em}
+.tally{display:inline-block;padding:2px 9px;border-radius:20px;font-size:12px;
+font-weight:600;margin-left:8px;font-variant-numeric:tabular-nums}
+.tally.e{background:var(--e-bg);color:var(--e-fg)}.tally.c{background:var(--c-bg);color:var(--c-fg)}
+table{border-collapse:collapse;width:100%;background:var(--card);font-size:13px;
+border:1px solid var(--line);border-radius:12px;overflow:hidden;box-shadow:var(--shadow)}
+th,td{padding:9px 13px;text-align:left;border-bottom:1px solid var(--line)}
+th{background:var(--th-bg);font-weight:600;font-size:11px;text-transform:uppercase;
+letter-spacing:.04em;color:var(--muted)}
+tr:last-child td{border-bottom:none}
+td.num{text-align:right;font-variant-numeric:tabular-nums}
+th.num{text-align:right}
+td.win{font-weight:600}td.win.envoy{color:var(--e-fg)}td.win.comp{color:var(--c-fg)}
+.grid-metrics{display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:14px}
+@media(max-width:720px){.grid-metrics{grid-template-columns:1fr}}
+.metric{background:var(--card);border:1px solid var(--line);border-radius:12px;
+padding:16px;box-shadow:var(--shadow)}
+.metric .unit{color:var(--muted);font-weight:400;font-size:12px}
+.chart{width:100%;height:auto;display:block;margin:4px 0}
+.chart .grid{stroke:var(--line);stroke-width:1}
+.chart .ylab{fill:var(--muted);font-size:10px;text-anchor:end;font-variant-numeric:tabular-nums}
+.chart .xlab{fill:var(--muted);font-size:10px;text-anchor:middle}
+.legend{display:flex;gap:14px;font-size:12px;color:var(--muted);margin-bottom:6px}
+.chip{display:flex;align-items:center;gap:5px}
+.chip i{width:11px;height:11px;border-radius:3px;display:inline-block}
+table.mini{margin-top:12px;font-size:12px;box-shadow:none}
+table.mini th,table.mini td{padding:5px 9px}
+.empty{color:var(--muted);font-style:italic;padding:30px 0;text-align:center}
+footer{margin-top:44px;color:var(--muted);font-size:12px;line-height:1.6}
+"""
+
+TEMPLATE = """<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Envoy vs {comp_title} — Performance Report</title>
+<style>{css}</style></head>
+<body><div class="wrap">
+<h1>Envoy Gateway vs {comp_title}</h1>
+<div class="sub">Load-test performance comparison</div>
+<div class="meta">
+  <span>Cluster <b>{cluster_id}</b></span>
+  <span>Test ID <b>{testid}</b></span>
+  <span>Rate window <b>{rate}</b></span>
+  <span>Envoy run <b>{envoy_dur}s</b></span>
+  <span>{comp_title} run <b>{comp_dur}s</b></span>
+  <span>Generated <b>{generated}</b></span>
+</div>
+
+<div class="verdict">
+  <div class="big">{overall}</div>
+  <div class="sub" style="margin-top:6px">Server-side metric wins:
+    <span class="tally e">Envoy {envoy_wins}</span>
+    <span class="tally c">{comp_title} {comp_wins}</span>
+  </div>
+</div>
+
+<h2>Summary</h2>
+<table>
+<tr><th>Metric</th><th class="num">Envoy</th><th class="num">{comp_title}</th><th class="num">Δ (Envoy vs {comp_title})</th><th>Better</th></tr>
+{summary_rows}
+</table>
+<div class="sub" style="margin-top:8px">Latency rows compare p99 means. Δ is Envoy relative to {comp_title};
+for latency/CPU/memory lower is better, for RPS/success-rate higher is better.</div>
+
+<h2>Server-side metrics</h2>
+<div class="grid-metrics">{sections}</div>
+
+<h2>k6 client-side (per scenario)</h2>
+<table>
+<tr><th>Metric</th><th class="num">Envoy scenario</th><th class="num">{comp_title} scenario</th></tr>
+{k6_rows}
+</table>
+
+<footer>
+Charts show values over elapsed test time (x = seconds since each scenario's start;
+the two scenarios ran in separate windows and are overlaid for comparison).
+Queries mirror the Grafana dashboards k6-tests-results, envoy-vs-nginx-loadtesting and
+envoy-vs-kong-loadtesting. Generated by the /perf-report skill.
+</footer>
+</div></body></html>
+"""
+
+
+def render_markdown(data, report_url=None):
+    """A compact Markdown summary suitable for a PR comment."""
+    meta = data["meta"]
+    comp_title = meta["competitor"].capitalize()
+    lines = [f"## 🚦 Envoy Gateway vs {comp_title} — performance report", ""]
+    lines.append(f"Cluster `{meta['cluster_id']}` · test `{meta['testid']}` · "
+                 f"Envoy {meta['envoy_window']['duration_s']}s / "
+                 f"{comp_title} {meta['competitor_window']['duration_s']}s")
+    lines.append("")
+    lines.append(f"| Metric | Envoy | {comp_title} | Δ | Better |")
+    lines.append("|---|--:|--:|--:|:--|")
+    e_wins = c_wins = 0
+    for entry in data["comparison"].values():
+        e = representative(entry["envoy"])
+        c = representative(entry["competitor"])
+        winner = "—"
+        if e is not None and c is not None:
+            lb = entry["lower_is_better"]
+            envoy_better = (e < c) if lb else (e > c)
+            winner = "**Envoy**" if envoy_better else f"**{comp_title}**"
+            e_wins += int(envoy_better)
+            c_wins += int(not envoy_better)
+        label = entry["title"] + (" (p99)" if entry["kind"] == "percentile" else "")
+        lines.append(f"| {label} | {fmt(entry['unit'], e)} | {fmt(entry['unit'], c)} "
+                     f"| {pct_delta(e, c)} | {winner} |")
+    overall = ("Envoy leads on the majority of server-side metrics."
+               if e_wins > c_wins else
+               f"{comp_title} leads on the majority of server-side metrics."
+               if c_wins > e_wins else "Evenly matched.")
+    lines += ["", f"**Verdict:** {overall} (server-side wins — Envoy {e_wins} / {comp_title} {c_wins})"]
+    if report_url:
+        lines += ["", f"📄 [Full report with charts]({report_url})"]
+    lines += ["", "<sub>Generated by the /perf-report skill from Mimir "
+              "(mirrors the Grafana Envoy-vs-* load-testing dashboards).</sub>"]
+    return "\n".join(lines)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--input", default="results.json")
+    ap.add_argument("--output", default="report.html")
+    ap.add_argument("--format", choices=["html", "markdown"], default="html")
+    ap.add_argument("--report-url", default=None,
+                    help="link inserted into the markdown summary (e.g. gist URL)")
+    args = ap.parse_args()
+    with open(args.input) as f:
+        data = json.load(f)
+    with open(args.output, "w") as f:
+        f.write(render_markdown(data, args.report_url) if args.format == "markdown"
+                else render(data))
+    print(f"Wrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `basicauth` performance test suite.
 - Add `keyauth` performance test suite.
 - Add `mobilelatency` performance test suite.
+- Add `perf-report` repo-specific claude skill.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `perf-report` repo-specific claude skill.
+
 ## [1.8.0] - 2026-07-14
 
 ### Added
@@ -14,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `basicauth` performance test suite.
 - Add `keyauth` performance test suite.
 - Add `mobilelatency` performance test suite.
-- Add `perf-report` repo-specific claude skill.
 
 ### Changed
 


### PR DESCRIPTION
## What

Adds a new `perf-report` claude skill that turns a finished Envoy Gateway load test into a ready-to-read HTML report plus a PR summary comment — no manual Grafana dashboard reading required.

Given an installation context, a workload `cluster_id`, and (optionally) a PR number, the skill:

1. Points kubectl at the installation and port-forwards Mimir.
2. Fetches metrics by running the same PromQL as the Grafana dashboards against the installation's Mimir.
3. Renders a self-contained HTML report (inline SVG charts, no external assets) and a Markdown PR summary.
4. Optionally publishes the report as a private gist and posts the summary as a PR comment.

The competitor (nginx vs kong) and both scenario time windows are auto-detected from the k6 series, so the user doesn't need to supply them.

## Components

- `.claude/skills/perf-report/SKILL.md` — workflow, required inputs, publishing steps, and documented limits.
- `.claude/skills/perf-reportqueries.yaml` — PromQL manifest that is the source of truth for what the report measures, mirrored byte-for-byte from the three networking Grafana dashboards (k6 results, envoy-vs-nginx, envoy-vs-kong) so the report and Grafana never disagree.
- `r.claude/skills/perf-reportfetch_metrics.py` — queries Mimir, auto-detects competitor + time windows, emits results.json. Requires python3 + PyYAML.
- `.claude/skills/perf-reportrender_report.py` — renders results.json to standalone HTML or Markdown, with a deterministic per-metric verdict against the k6 SLO thresholds (p95 < 500ms / p99 < 1000ms / error < 0.1%). No third-party deps.


## Notes

The two scenarios run in separate time windows (Envoy first, competitor after); charts overlay them on a common elapsed-time axis — they are not concurrent traffic.
nginx exposes no upstream-latency histogram, so that comparison is Envoy-only on nginx runs (expected, not a bug).
Latencies are normalized to milliseconds to match the dashboards.
### Checklist

- [ ] Update changelog in CHANGELOG.md.
