### PR TITLE
feat: set karpenter do-not-disrupt on the control-plane pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Set `karpenter.sh/do-not-disrupt: "true"` on the Envoy Gateway control-plane pods, so Karpenter does not voluntarily consolidate them. A control-plane reschedule forces the Envoy proxies to reconnect and can leave them wedged with stale/absent TLS secrets over delta xDS until restarted (see [envoyproxy/gateway#9519](https://github.com/envoyproxy/gateway/issues/9519)).
+
 ## [1.8.0] - 2026-07-14
 
 ### Added

--- a/diffs/helm__envoy-gateway__values.schema.json.patch
+++ b/diffs/helm__envoy-gateway__values.schema.json.patch
@@ -1,9 +1,9 @@
 diff --git a/helm/envoy-gateway/values.schema.json b/helm/envoy-gateway/values.schema.json
 new file mode 100644
-index 0000000..c435adf
+index 0000000..7af996e
 --- /dev/null
 +++ b/helm/envoy-gateway/values.schema.json
-@@ -0,0 +1,568 @@
+@@ -0,0 +1,571 @@
 +{
 +    "$schema": "http://json-schema.org/schema#",
 +    "type": "object",
@@ -310,6 +310,9 @@ index 0000000..c435adf
 +                        "annotations": {
 +                            "type": "object",
 +                            "properties": {
++                                "karpenter.sh/do-not-disrupt": {
++                                    "type": "string"
++                                },
 +                                "prometheus.io/port": {
 +                                    "type": "string"
 +                                },

--- a/diffs/helm__envoy-gateway__values.yaml.patch
+++ b/diffs/helm__envoy-gateway__values.yaml.patch
@@ -1,5 +1,5 @@
 diff --git a/vendor/gateway-helm/values.yaml b/helm/envoy-gateway/values.yaml
-index 6189f1e..5c479b1 100644
+index 6189f1e..4f70e67 100644
 --- a/vendor/gateway-helm/values.yaml
 +++ b/helm/envoy-gateway/values.yaml
 @@ -2,7 +2,8 @@
@@ -69,7 +69,7 @@ index 6189f1e..5c479b1 100644
        seccompProfile:
          type: RuntimeDefault
    ports:
-@@ -88,15 +88,21 @@ deployment:
+@@ -88,15 +88,26 @@ deployment:
      - name: metrics
        port: 19001
        targetPort: 19001
@@ -82,6 +82,11 @@ index 6189f1e..5c479b1 100644
      annotations:
        prometheus.io/scrape: 'true'
        prometheus.io/port: '19001'
++      # Prevent Karpenter from voluntarily disrupting (consolidating) the control-plane
++      # pods. A control-plane reschedule forces the Envoy proxies to reconnect and can
++      # leave them wedged with stale/absent TLS secrets over delta xDS until they are
++      # restarted (see https://github.com/envoyproxy/gateway/issues/9519).
++      karpenter.sh/do-not-disrupt: 'true'
      labels: {}
 -    topologySpreadConstraints: []
 +    topologySpreadConstraints:
@@ -94,7 +99,7 @@ index 6189f1e..5c479b1 100644
      tolerations: []
      nodeSelector: {}
      # Additional volumeMounts on the deployment definition.
-@@ -120,10 +126,16 @@ service:
+@@ -120,10 +131,16 @@ service:
    type: "ClusterIP"
  
  hpa:
@@ -115,7 +120,7 @@ index 6189f1e..5c479b1 100644
    behavior: {}
  
  config:
-@@ -154,7 +166,12 @@ certgen:
+@@ -154,7 +171,12 @@ certgen:
      pod:
        annotations: {}
        labels: {}
@@ -129,7 +134,7 @@ index 6189f1e..5c479b1 100644
      affinity: {}
      tolerations: []
      nodeSelector: {}
-@@ -178,3 +195,36 @@ certgen:
+@@ -178,3 +200,36 @@ certgen:
  topologyInjector:
    enabled: true
    annotations: {}

--- a/helm/envoy-gateway/README.md
+++ b/helm/envoy-gateway/README.md
@@ -76,6 +76,7 @@ To uninstall the chart:
 | deployment.envoyGateway.securityContext.runAsUser | int | `65532` |  |
 | deployment.envoyGateway.securityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | deployment.pod.affinity | object | `{}` |  |
+| deployment.pod.annotations."karpenter.sh/do-not-disrupt" | string | `"true"` |  |
 | deployment.pod.annotations."prometheus.io/port" | string | `"19001"` |  |
 | deployment.pod.annotations."prometheus.io/scrape" | string | `"true"` |  |
 | deployment.pod.extraVolumeMounts | list | `[]` |  |

--- a/helm/envoy-gateway/values.schema.json
+++ b/helm/envoy-gateway/values.schema.json
@@ -304,6 +304,9 @@
                         "annotations": {
                             "type": "object",
                             "properties": {
+                                "karpenter.sh/do-not-disrupt": {
+                                    "type": "string"
+                                },
                                 "prometheus.io/port": {
                                     "type": "string"
                                 },

--- a/helm/envoy-gateway/values.yaml
+++ b/helm/envoy-gateway/values.yaml
@@ -95,6 +95,11 @@ deployment:
     annotations:
       prometheus.io/scrape: 'true'
       prometheus.io/port: '19001'
+      # Prevent Karpenter from voluntarily disrupting (consolidating) the control-plane
+      # pods. A control-plane reschedule forces the Envoy proxies to reconnect and can
+      # leave them wedged with stale/absent TLS secrets over delta xDS until they are
+      # restarted (see https://github.com/envoyproxy/gateway/issues/9519).
+      karpenter.sh/do-not-disrupt: 'true'
     labels: {}
     topologySpreadConstraints:
       - maxSkew: 1

--- a/sync/patches/values/values.schema.json
+++ b/sync/patches/values/values.schema.json
@@ -304,6 +304,9 @@
                         "annotations": {
                             "type": "object",
                             "properties": {
+                                "karpenter.sh/do-not-disrupt": {
+                                    "type": "string"
+                                },
                                 "prometheus.io/port": {
                                     "type": "string"
                                 },

--- a/sync/patches/values/values.yaml
+++ b/sync/patches/values/values.yaml
@@ -95,6 +95,11 @@ deployment:
     annotations:
       prometheus.io/scrape: 'true'
       prometheus.io/port: '19001'
+      # Prevent Karpenter from voluntarily disrupting (consolidating) the control-plane
+      # pods. A control-plane reschedule forces the Envoy proxies to reconnect and can
+      # leave them wedged with stale/absent TLS secrets over delta xDS until they are
+      # restarted (see https://github.com/envoyproxy/gateway/issues/9519).
+      karpenter.sh/do-not-disrupt: 'true'
     labels: {}
     topologySpreadConstraints:
       - maxSkew: 1


### PR DESCRIPTION
This PR:

- Sets `karpenter.sh/do-not-disrupt: "true"` on the Envoy Gateway control-plane pod template, so Karpenter does not voluntarily consolidate the control plane.

Towards: https://github.com/envoyproxy/gateway/issues/9519

### Why

A control-plane reschedule makes the Envoy proxies reconnect and re-establish their delta xDS stream. A later listener/cluster update can then leave a proxy wedged with stale/absent TLS secrets (SDS re-subscription is never answered), and it does not self-heal — the proxy pod must be restarted. This caused a ~14-minute silent HTTPS outage on a management cluster (root cause + evidence in the linked issue).

The Envoy **proxy** pods already carry `karpenter.sh/do-not-disrupt` (via the `EnvoyProxy` CRs); this brings the **control plane** in line.

Note this is defence-in-depth, not the fix:
- It only prevents *voluntary* disruption (consolidation — the exact trigger of the incident). Involuntary restarts (upgrades, crashes, node failures) still cycle the control plane.
- HA (2 replicas, added in v1.8.0) keeps the control plane *available* but does **not** prevent the re-arming: a single-replica eviction still forces a proxy reconnect. do-not-disrupt and HA are complementary.
- The underlying proxy-side fault is upstream (envoyproxy/gateway#9519); detection was added in giantswarm/prometheus-rules#2087.

### How

Edited the values patch source (`sync/patches/values/values.yaml` and `values.schema.json`) and regenerated `helm/` and `diffs/`. Rendered output confirmed: the annotation lands on the `envoy-gateway` control-plane pod; `helm lint` and schema validation pass.

### Checklist

- [x] Update changelog in CHANGELOG.md.
