### PR TITLE
chore(tests): fix performance tests suites by udapting cert-manager values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update cert-manager config in the cluster values for all performance test suites.
+
 ## [1.8.0] - 2026-07-14
 
 ### Added

--- a/tests/performance/suites/basic/cluster_values_test.go
+++ b/tests/performance/suites/basic/cluster_values_test.go
@@ -19,10 +19,11 @@ const baseClusterValues = `global:
   apps:
     certManager:
       values:
-        config:
-          apiVersion: controller.config.cert-manager.io/v1alpha1
-          enableGatewayAPI: true
-          kind: ControllerConfiguration
+        cert-manager:
+          config:
+            apiVersion: controller.config.cert-manager.io/v1alpha1
+            enableGatewayAPI: true
+            kind: ControllerConfiguration
   connectivity:
     certManager:
       useDnsChallenges: true

--- a/tests/performance/suites/basic/test_data/cluster_values.yaml
+++ b/tests/performance/suites/basic/test_data/cluster_values.yaml
@@ -2,10 +2,11 @@ global:
   apps:
     certManager:
       values:
-        config:
-          apiVersion: controller.config.cert-manager.io/v1alpha1
-          enableGatewayAPI: true
-          kind: ControllerConfiguration
+        cert-manager:
+          config:
+            apiVersion: controller.config.cert-manager.io/v1alpha1
+            enableGatewayAPI: true
+            kind: ControllerConfiguration
   connectivity:
     certManager:
       useDnsChallenges: true

--- a/tests/performance/suites/basicauth/cluster_values_test.go
+++ b/tests/performance/suites/basicauth/cluster_values_test.go
@@ -19,10 +19,11 @@ const baseClusterValues = `global:
   apps:
     certManager:
       values:
-        config:
-          apiVersion: controller.config.cert-manager.io/v1alpha1
-          enableGatewayAPI: true
-          kind: ControllerConfiguration
+        cert-manager:
+          config:
+            apiVersion: controller.config.cert-manager.io/v1alpha1
+            enableGatewayAPI: true
+            kind: ControllerConfiguration
   connectivity:
     certManager:
       useDnsChallenges: true

--- a/tests/performance/suites/basicauth/test_data/cluster_values.yaml
+++ b/tests/performance/suites/basicauth/test_data/cluster_values.yaml
@@ -2,10 +2,11 @@ global:
   apps:
     certManager:
       values:
-        config:
-          apiVersion: controller.config.cert-manager.io/v1alpha1
-          enableGatewayAPI: true
-          kind: ControllerConfiguration
+        cert-manager:
+          config:
+            apiVersion: controller.config.cert-manager.io/v1alpha1
+            enableGatewayAPI: true
+            kind: ControllerConfiguration
   connectivity:
     certManager:
       useDnsChallenges: true

--- a/tests/performance/suites/keyauth/test_data/cluster_values.yaml
+++ b/tests/performance/suites/keyauth/test_data/cluster_values.yaml
@@ -2,10 +2,11 @@ global:
   apps:
     certManager:
       values:
-        config:
-          apiVersion: controller.config.cert-manager.io/v1alpha1
-          enableGatewayAPI: true
-          kind: ControllerConfiguration
+        cert-manager:
+          config:
+            apiVersion: controller.config.cert-manager.io/v1alpha1
+            enableGatewayAPI: true
+            kind: ControllerConfiguration
   connectivity:
     dns:
       wildcardCnameTarget: gateway

--- a/tests/performance/suites/mobilelatency/cluster_values_test.go
+++ b/tests/performance/suites/mobilelatency/cluster_values_test.go
@@ -19,10 +19,11 @@ const baseClusterValues = `global:
   apps:
     certManager:
       values:
-        config:
-          apiVersion: controller.config.cert-manager.io/v1alpha1
-          enableGatewayAPI: true
-          kind: ControllerConfiguration
+        cert-manager:
+          config:
+            apiVersion: controller.config.cert-manager.io/v1alpha1
+            enableGatewayAPI: true
+            kind: ControllerConfiguration
   connectivity:
     certManager:
       useDnsChallenges: true

--- a/tests/performance/suites/mobilelatency/test_data/cluster_values.yaml
+++ b/tests/performance/suites/mobilelatency/test_data/cluster_values.yaml
@@ -2,10 +2,11 @@ global:
   apps:
     certManager:
       values:
-        config:
-          apiVersion: controller.config.cert-manager.io/v1alpha1
-          enableGatewayAPI: true
-          kind: ControllerConfiguration
+        cert-manager:
+          config:
+            apiVersion: controller.config.cert-manager.io/v1alpha1
+            enableGatewayAPI: true
+            kind: ControllerConfiguration
   connectivity:
     certManager:
       useDnsChallenges: true


### PR DESCRIPTION
Towards https://gigantic.slack.com/archives/C02HLSDH3DZ/p1784554580680559?thread_ts=1784111753.397129&cid=C02HLSDH3DZ

Since the [breaking change](https://github.com/giantswarm/cert-manager-app/releases/tag/v4.0.0) in cert-manager 4.0.0, the performance tests were failing. This PR fixes it by updating the cert-manager values used in the cluster to match those breaking changes.

### Checklist

- [x] Update changelog in CHANGELOG.md.
