### PR TITLE
fix(claude): move report pushing out of the skill and into the pipeline

### DIFF
--- a/.claude/perf-report-ci-settings.json
+++ b/.claude/perf-report-ci-settings.json
@@ -11,10 +11,6 @@
       "Bash(cp *)",
       "Bash(mv *)",
       "Bash(curl *)",
-      "Bash(gh api *)",
-      "Bash(gh pr view *)",
-      "Bash(gh pr comment *)",
-      "Bash(gh auth status *)",
       "Bash(kubectl get *)",
       "Bash(kubectl -n * get *)",
       "Bash(kubectl --context * get *)",
@@ -31,7 +27,8 @@
       "Bash(kubectl apply *)",
       "Bash(kubectl patch *)",
       "Bash(git push *)",
-      "Bash(git commit *)"
+      "Bash(git commit *)",
+      "Bash(gh *)"
     ]
   }
 }

--- a/.claude/skills/perf-report/README.md
+++ b/.claude/skills/perf-report/README.md
@@ -142,6 +142,20 @@ A port-forward to the in-cluster service bypasses the route and serves the full
 Prometheus API, which is why `_get()` also carries a retry loop: that tunnel
 stalls periodically and a report makes ~30 sequential range queries.
 
+### The pipeline publishes, the agent only analyses
+
+`generate-perf-report` does the branch creation, tarball upload, upload
+verification, markdown re-render and PR comment in its own bash, not through the
+agent. Three consecutive runs failed in the publish step, each for a different
+reason — a `cd` outside the working directory, a nested `$(gh api ...)`
+substitution, and a `gh api --method PUT` pipeline whose denial could not be
+reproduced in isolation. Every individual feature of those commands is
+allowlistable, but the agent composes a slightly different command each run, so
+the allowlist could never be complete. Task bash is not permission-gated, so this
+is deterministic; and the download URL is now only written *after* an upload the
+task verified with a read-back, which is what stops a comment carrying a dead
+link. The agent writes `narrative.md` and the task prepends it to the comment.
+
 ### Permissions in the pipeline
 
 The task runs `claude --permission-mode dontAsk`, which never prompts and
@@ -159,6 +173,11 @@ Two things about that allowlist are easy to get wrong:
   `Bash(python3 *)` is allowed — and no extra rule can fix it, because the
   restriction is on matching past the assignment. This is why the steps above
   spell every path out literally. It cost one whole pipeline run.
+- **A `cd` outside the working directory cannot be allowlisted.** `Bash(cd /some/path*)` has no
+  effect — Claude Code decides `cd` from the session's allowed directories, not from Bash rules
+  (verified). The pipeline therefore passes `--add-dir` for its output directory; without it the
+  agent's `cd <out-dir> && … | gh api …` upload is denied and the tarball never reaches the
+  `perf-reports` branch, while the PR comment still posts, so the run looks half-successful.
 - **`env` is intentionally not allowlisted.** The agent sometimes tries
   `env | grep -c MIMIR_USERNAME` as a sanity check; that gets denied and it
   retries without it, which is fine. Do not "fix" this by allowing `env` — the

--- a/.claude/skills/perf-report/SKILL.md
+++ b/.claude/skills/perf-report/SKILL.md
@@ -160,6 +160,16 @@ Work in a scratch dir.
    gists can't hold binaries, so upload the tarball to the repo's dedicated
    `perf-reports` branch and link its download URL.
 
+   > **Pipeline mode: skip this entire step.** The `generate-perf-report` Tekton
+   > task publishes by itself — it creates the branch, uploads the tarball,
+   > verifies it is readable, re-renders the markdown with the resulting URL and
+   > posts the comment. Write your interpretation to `narrative.md` in the output
+   > directory instead and stop; the task prepends it to the comment. Do not run
+   > `gh` at all (the CI allowlist denies it), and do not construct a download URL
+   > yourself — a URL written before a verified upload produces a comment with a
+   > dead link, which is exactly what happened before this was moved out of the
+   > agent's hands.
+
    ```bash
    REPO=giantswarm/envoy-gateway-app
    BRANCH=perf-reports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     filtered on the `kube-system` namespace, but the performance suites install
     `ingress-nginx` into `default`, so those three metrics were always empty and
     the comparison table rendered them as `—`.
+  - in pipeline mode the skill no longer publishes: the `generate-perf-report`
+    Tekton task creates the branch, uploads the tarball, verifies it and posts the
+    comment itself, and the agent writes its interpretation to `narrative.md`
+    instead. `gh` moved from the CI allowlist's allow list to its deny list.
   - retry Mimir requests in `fetch_metrics.py`, so a report survives the stalls
     of a `kubectl port-forward` to the management cluster.
   - add `.claude/perf-report-ci-settings.json`, the permission allowlist used by


### PR DESCRIPTION
The report is well generated and compressed into a tar in the pipeline but claude fails to push it to Github because of permissions issues (even with the allowlist). This PR moves the pushing part out from the agent to rely on the pipeline's pod own permissions which should be enough to have the tar pushed in Github.

### Checklist

- [x] Update changelog in CHANGELOG.md.
