### PR TITLE
fix: keep all envoy-gateway images on the configured registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Point the `eg.image` fallback at the `gsoci.azurecr.io` mirror. When both `global.images.envoyGateway.image` and `deployment.envoyGateway.image.repository` are empty, the chart resolved the Envoy Gateway control plane, certgen and `shutdownManager` images to `docker.io/envoyproxy/gateway:<chart version>` — a tag that never exists upstream, ignoring `global.imageRegistry`.
+- Honour `global.imageRegistry` and `global.imagePullSecrets` in the CRD installer Job, so the `envoy-gateway-crds` image can be pulled from a private mirror like every other image in the chart.
 
 ## [1.10.0] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Point the `eg.image` fallback at the `gsoci.azurecr.io` mirror. When both `global.images.envoyGateway.image` and `deployment.envoyGateway.image.repository` are empty, the chart resolved the Envoy Gateway control plane, certgen and `shutdownManager` images to `docker.io/envoyproxy/gateway:<chart version>` — a tag that never exists upstream, ignoring `global.imageRegistry`.
+
 ## [1.10.0] - 2026-08-19
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ The core pattern is: **vendir + ordered patches**.
 - `vendor/` — contains the raw upstream chart after `vendir sync`
 - `sync/sync.sh` — orchestrates the full sync: runs vendir, applies patches, generates diffs
 - `sync/patches/` — Git patch files applied in this order:
-  1. `image-registry` — switches image registry to `gsoci.azurecr.io`
+  1. `image-registry` — points the `eg.image` fallback at the `gsoci.azurecr.io` mirror at `appVersion`
   2. `team-label` — adds `app.giantswarm.io/team: cabbage` labels
   3. `backend` — safe enable/disable of the Backend extension API
   4. `kyverno-policies` — restricts Backend API (blocks localhost, metadata service, admin port)

--- a/diffs/helm__envoy-gateway__templates___helpers.tpl.patch
+++ b/diffs/helm__envoy-gateway__templates___helpers.tpl.patch
@@ -1,5 +1,5 @@
 diff --git a/vendor/gateway-helm/templates/_helpers.tpl b/helm/envoy-gateway/templates/_helpers.tpl
-index df9bb58..8d4db30 100644
+index df9bb58..ca5a6fe 100644
 --- a/vendor/gateway-helm/templates/_helpers.tpl
 +++ b/helm/envoy-gateway/templates/_helpers.tpl
 @@ -47,6 +47,7 @@ helm.sh/chart: {{ include "eg.chart" . }}
@@ -10,6 +10,15 @@ index df9bb58..8d4db30 100644
  {{- with .Values.commonLabels }}
  {{ toYaml . }}
  {{- end }}
+@@ -100,7 +101,7 @@ The name of the Envoy Gateway image.
+ {{-   $imageTag := $repositoryParts._1 -}}
+ {{-   printf "%s/%s:%s" $registryName $repositoryName $imageTag -}}
+ {{- else -}}
+-docker.io/envoyproxy/gateway:{{ .Chart.Version }}
++{{- printf "%s/giantswarm/envoyproxy-gateway:v%s" (default "gsoci.azurecr.io" .Values.global.imageRegistry) .Chart.AppVersion -}}
+ {{- end -}}
+ {{- end -}}
+ 
 @@ -236,10 +237,16 @@ provider:
        {{- end }}
      shutdownManager:

--- a/diffs/helm__envoy-gateway__templates__crds__job.yaml.patch
+++ b/diffs/helm__envoy-gateway__templates__crds__job.yaml.patch
@@ -1,9 +1,9 @@
 diff --git a/helm/envoy-gateway/templates/crds/job.yaml b/helm/envoy-gateway/templates/crds/job.yaml
 new file mode 100644
-index 0000000..795ba9b
+index 0000000..5bcf656
 --- /dev/null
 +++ b/helm/envoy-gateway/templates/crds/job.yaml
-@@ -0,0 +1,62 @@
+@@ -0,0 +1,66 @@
 +apiVersion: batch/v1
 +kind: Job
 +metadata:
@@ -24,6 +24,10 @@ index 0000000..795ba9b
 +        {{- include "eg.labels" . | nindent 8 }}
 +    spec:
 +      serviceAccountName: {{ .Chart.Name }}-crd-installer
++      {{- with .Values.global.imagePullSecrets }}
++      imagePullSecrets:
++        {{- toYaml . | nindent 8 }}
++      {{- end }}
 +      securityContext:
 +        runAsNonRoot: true
 +        runAsUser: 1000
@@ -39,7 +43,7 @@ index 0000000..795ba9b
 +        effect: NoSchedule
 +      containers:
 +      - name: crd-installer
-+        image: {{ .Values.crds.image.registry }}/{{ .Values.crds.image.repository }}:{{ .Chart.Version | splitList "+" | first }}
++        image: {{ default .Values.crds.image.registry .Values.global.imageRegistry }}/{{ .Values.crds.image.repository }}:{{ .Chart.Version | splitList "+" | first }}
 +        imagePullPolicy: IfNotPresent
 +        command:
 +        - sh

--- a/diffs/helm__envoy-gateway__values.yaml.patch
+++ b/diffs/helm__envoy-gateway__values.yaml.patch
@@ -1,5 +1,5 @@
 diff --git a/vendor/gateway-helm/values.yaml b/helm/envoy-gateway/values.yaml
-index a999508..b8441fd 100644
+index a999508..e4b60a6 100644
 --- a/vendor/gateway-helm/values.yaml
 +++ b/helm/envoy-gateway/values.yaml
 @@ -2,7 +2,7 @@
@@ -29,7 +29,7 @@ index a999508..b8441fd 100644
        # Specify image pull policy if default behavior isn't desired.
        # Default behavior: latest images will be Always else IfNotPresent.
        pullPolicy: IfNotPresent
-@@ -30,25 +30,22 @@ global:
+@@ -30,31 +30,28 @@ global:
        # This updates the generated `envoyProxy` config and does not change the `envoy-gateway`
        # control plane Deployment image. If not specified, the default image built into
        # `envoy-gateway` is used.
@@ -61,6 +61,13 @@ index a999508..b8441fd 100644
  
  deployment:
    annotations: {}
+   envoyGateway:
+     image:
+-      # if both this and global.imageRegistry are specified, this has to include both registry and repository explicitly, eg docker.io/envoyproxy/gateway
++      # if both this and global.imageRegistry are specified, this has to include both registry and repository explicitly, eg gsoci.azurecr.io/giantswarm/envoyproxy-gateway
+       repository: ""
+       tag: ""
+     imagePullPolicy: ""
 @@ -124,15 +121,26 @@ deployment:
      - name: metrics
        port: 19001

--- a/helm/envoy-gateway/templates/_helpers.tpl
+++ b/helm/envoy-gateway/templates/_helpers.tpl
@@ -101,7 +101,7 @@ The name of the Envoy Gateway image.
 {{-   $imageTag := $repositoryParts._1 -}}
 {{-   printf "%s/%s:%s" $registryName $repositoryName $imageTag -}}
 {{- else -}}
-docker.io/envoyproxy/gateway:{{ .Chart.Version }}
+{{- printf "%s/giantswarm/envoyproxy-gateway:v%s" (default "gsoci.azurecr.io" .Values.global.imageRegistry) .Chart.AppVersion -}}
 {{- end -}}
 {{- end -}}
 

--- a/helm/envoy-gateway/templates/crds/job.yaml
+++ b/helm/envoy-gateway/templates/crds/job.yaml
@@ -18,6 +18,10 @@ spec:
         {{- include "eg.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .Chart.Name }}-crd-installer
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -33,7 +37,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: crd-installer
-        image: {{ .Values.crds.image.registry }}/{{ .Values.crds.image.repository }}:{{ .Chart.Version | splitList "+" | first }}
+        image: {{ default .Values.crds.image.registry .Values.global.imageRegistry }}/{{ .Values.crds.image.repository }}:{{ .Chart.Version | splitList "+" | first }}
         imagePullPolicy: IfNotPresent
         command:
         - sh

--- a/helm/envoy-gateway/values.yaml
+++ b/helm/envoy-gateway/values.yaml
@@ -51,7 +51,7 @@ deployment:
   annotations: {}
   envoyGateway:
     image:
-      # if both this and global.imageRegistry are specified, this has to include both registry and repository explicitly, eg docker.io/envoyproxy/gateway
+      # if both this and global.imageRegistry are specified, this has to include both registry and repository explicitly, eg gsoci.azurecr.io/giantswarm/envoyproxy-gateway
       repository: ""
       tag: ""
     imagePullPolicy: ""

--- a/sync/patches/crds/crds-job.yaml
+++ b/sync/patches/crds/crds-job.yaml
@@ -18,6 +18,10 @@ spec:
         {{- include "eg.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .Chart.Name }}-crd-installer
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -33,7 +37,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: crd-installer
-        image: {{ .Values.crds.image.registry }}/{{ .Values.crds.image.repository }}:{{ .Chart.Version | splitList "+" | first }}
+        image: {{ default .Values.crds.image.registry .Values.global.imageRegistry }}/{{ .Values.crds.image.repository }}:{{ .Chart.Version | splitList "+" | first }}
         imagePullPolicy: IfNotPresent
         command:
         - sh

--- a/sync/patches/image-registry/000-image-fallback.patch
+++ b/sync/patches/image-registry/000-image-fallback.patch
@@ -1,0 +1,11 @@
+diff --git a/helm/envoy-gateway/templates/_helpers.tpl b/helm/envoy-gateway/templates/_helpers.tpl
+--- a/helm/envoy-gateway/templates/_helpers.tpl
++++ b/helm/envoy-gateway/templates/_helpers.tpl
+@@ -100,6 +100,6 @@
+ {{-   $imageTag := $repositoryParts._1 -}}
+ {{-   printf "%s/%s:%s" $registryName $repositoryName $imageTag -}}
+ {{- else -}}
+-docker.io/envoyproxy/gateway:{{ .Chart.Version }}
++{{- printf "%s/giantswarm/envoyproxy-gateway:v%s" (default "gsoci.azurecr.io" .Values.global.imageRegistry) .Chart.AppVersion -}}
+ {{- end -}}
+ {{- end -}}

--- a/sync/patches/image-registry/patch.sh
+++ b/sync/patches/image-registry/patch.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+repo_dir=$(git rev-parse --show-toplevel) ; readonly repo_dir
+script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd ) ; readonly script_dir
+
+cd "${repo_dir}"
+
+readonly script_dir_rel=".${script_dir#"${repo_dir}"}"
+
+# Upstream's `eg.image` fallback hardcodes `docker.io/envoyproxy/gateway:{{ .Chart.Version }}`.
+# Our chart version is our own (it does not track appVersion), so that tag never exists, and the
+# fallback ignores `global.imageRegistry` entirely. Point it at the gsoci mirror instead.
+# `git apply` fails the sync if upstream reworks the helper, so the fix cannot be lost silently.
+set -x
+git apply "${script_dir_rel}/000-image-fallback.patch"
+
+{ set +x; } 2>/dev/null

--- a/sync/patches/values/values.yaml
+++ b/sync/patches/values/values.yaml
@@ -51,7 +51,7 @@ deployment:
   annotations: {}
   envoyGateway:
     image:
-      # if both this and global.imageRegistry are specified, this has to include both registry and repository explicitly, eg docker.io/envoyproxy/gateway
+      # if both this and global.imageRegistry are specified, this has to include both registry and repository explicitly, eg gsoci.azurecr.io/giantswarm/envoyproxy-gateway
       repository: ""
       tag: ""
     imagePullPolicy: ""

--- a/sync/sync.sh
+++ b/sync/sync.sh
@@ -16,6 +16,7 @@ vendir sync
 find vendor/ -type f -exec sed -i 's/[[:space:]]*$//' {} \;
 
 # Patches
+./sync/patches/image-registry/patch.sh
 ./sync/patches/team-label/patch.sh
 ./sync/patches/backend/patch.sh
 ./sync/patches/kyverno-policies/patch.sh


### PR DESCRIPTION
This PR:

- points the `eg.image` fallback at the `gsoci.azurecr.io` mirror instead of `docker.io/envoyproxy/gateway:{{ .Chart.Version }}`
- makes the CRD installer Job honour `global.imageRegistry` and `global.imagePullSecrets`
- reinstates `sync/patches/image-registry/` so the first fix survives future `vendir` bumps

Towards: no issue — found while sweeping our charts for images that can still resolve off-mirror (third instance after `resource-police` and `release-exporter`).

### The bug

`eg.image` ended in upstream's hardcoded fallback:

```
{{- else -}}
docker.io/envoyproxy/gateway:{{ .Chart.Version }}
{{- end -}}
```

It is reachable: `global.images.envoyGateway.image` is an optional plain `string` in `values.schema.json` (not required, no `minLength`), and `deployment.envoyGateway.image.repository` is `""` by default, so blanking the former falls straight through. On `main`:

```console
$ helm template eg helm/envoy-gateway --set global.images.envoyGateway.image=""
        image: docker.io/envoyproxy/gateway:1.10.0
```

That is wrong twice. It ignores `global.imageRegistry`, so even someone who configured a private registry gets sent to Docker Hub — breaking air-gapped installs, the China registry path and any registry allowlist. And it tags with our **chart** version (`1.10.0`) rather than `appVersion` (`1.9.0`), a tag that has never existed upstream, so it is a guaranteed `ImagePullBackOff` rather than merely an off-mirror pull.

It lands on three workloads, including the data plane: the control-plane Deployment, the certgen Job, and the EnvoyProxy `shutdownManager`.

The fallback was orphaned in v1.10.0, when the `image-registry` patch was dropped after upstream started supporting `global.imageRegistry` natively. The three healthy branches of the same helper already use `.Chart.AppVersion`; only the fallback did not.

### The fix

```
{{- printf "%s/giantswarm/envoyproxy-gateway:v%s" (default "gsoci.azurecr.io" .Values.global.imageRegistry) .Chart.AppVersion -}}
```

`appVersion` comes from `vendir.lock.yml` via the `chart_yaml` patch, so the version is not duplicated anywhere and self-updates on the next upstream bump.

This lives in a reinstated `sync/patches/image-registry/` rather than as a direct edit under `helm/`, so it is not silently lost on the next `vendir` sync. It is applied with `git apply`, which means an upstream rework of the helper aborts `sync.sh` (`set -o errexit`) instead of quietly dropping the patch — verified by mangling the upstream line and watching the sync fail.

### Second fix: the CRD installer Job

Spotted while verifying the first one. The Job built its image from `crds.image.registry` alone, so it was the one workload that ignored `global.imageRegistry` — with a private mirror configured, everything else moved and the CRD installer still pulled from gsoci. It also set no `imagePullSecrets`, so it could not authenticate against a mirror that needs credentials. Its `.Chart.Version` tag is left alone: that one is correct by design, since this repo builds and pushes `envoy-gateway-crds` per release tag.

### Verification

- **Default render is byte-identical to `main`** — only the fallback and the private-mirror paths move.
- Fallback now renders `gsoci.azurecr.io/giantswarm/envoyproxy-gateway:v1.9.0` at all three sites; no `docker.io` anywhere.
- With `--set global.imageRegistry=my.registry.io`, all four images follow the mirror:
  ```
  my.registry.io/giantswarm/envoyproxy-gateway:v1.9.0
  my.registry.io/giantswarm/envoy:distroless-v1.39.0
  my.registry.io/giantswarm/envoyproxy-ratelimit:17b1956c
  my.registry.io/giantswarm/envoy-gateway-crds:1.10.0
  ```
- `global.imagePullSecrets` renders on the CRD Job when set, and nothing when unset.
- `./sync/sync.sh` is idempotent across repeated runs; `helm lint` clean.

### Checklist

- [x] Update changelog in CHANGELOG.md.
